### PR TITLE
[DRAFT] Deduplicating by Message ID by grouping by Message ID

### DIFF
--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_bounces_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_bounces_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_global_message_email_bounces_rollup(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
- SAFE_CAST(hard_bounces + soft_bounces AS INT) AS total_bounces,
-  SAFE_CAST(0 AS INT) AS block_bounces,
-  SAFE_CAST(0 AS INT) AS tech_bounces,
-  SAFE_CAST(soft_bounces AS INT) AS soft_bounces,
-  SAFE_CAST(hard_bounces AS INT) AS unknown_bounces
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,
+ SUM(SAFE_CAST(hard_bounces + soft_bounces AS INT)) AS total_bounces,
+  SUM(SAFE_CAST(0 AS INT)) AS block_bounces,
+  SUM(SAFE_CAST(0 AS INT)) AS tech_bounces,
+  SUM(SAFE_CAST(soft_bounces AS INT)) AS soft_bounces,
+  SUM(SAFE_CAST(hard_bounces AS INT)) AS unknown_bounces
 FROM {{ ref(reference_name) }} 
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_clicks_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_clicks_rollup.sql
@@ -1,6 +1,7 @@
 {% macro create_stg_frakture_global_message_email_clicks_rollup(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,  
-  SAFE_CAST(clicks AS INT) AS clicks
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
+  SUM(SAFE_CAST(clicks AS INT)) AS clicks
 FROM {{ ref(reference_name) }} 
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.sql
@@ -1,6 +1,6 @@
 {% macro create_stg_frakture_global_message_email_jobs(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT 
+WITH BASE AS (SELECT 
    SAFE_CAST(message_id AS STRING) AS message_id,
    SAFE_CAST(campaign_id AS STRING) AS campaign_id,
 ## to do: extract from name and from email from the "from_name" value and split
@@ -13,5 +13,7 @@ SELECT DISTINCT
     SAFE_CAST(label AS STRING) AS email_name,
     SAFE_CAST(subject AS STRING) AS email_subject,
     SAFE_CAST(campaign_name AS STRING) AS campaign_name
-FROM {{ ref(reference_name) }}
+FROM {{ ref(reference_name) }})
+
+SELECT DISTINCT * FROM BASE
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_opens_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_opens_rollup.sql
@@ -1,6 +1,7 @@
 {% macro create_stg_frakture_global_message_email_opens_rollup(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(impressions AS INT) AS opens
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,
+  SUM(SAFE_CAST(impressions AS INT)) AS opens
 FROM {{ ref(reference_name) }} 
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_recipients_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_recipients_rollup.sql
@@ -1,6 +1,7 @@
 {% macro create_stg_frakture_global_message_email_recipients_rollup(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(sent AS INT) AS recipients
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,
+  SUM(SAFE_CAST(sent AS INT)) AS recipients
 FROM {{ ref(reference_name) }} 
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_sources_campaigns_messages_bridge.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_sources_campaigns_messages_bridge.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_sources_campaigns_messages_bridge(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
+WITH BASE AS (SELECT SAFE_CAST(message_id AS STRING) AS message_id,
        SAFE_CAST(primary_source_code AS STRING) AS source_code,       
        SAFE_CAST(campaign_id AS STRING) AS campaign_id
-FROM  {{ ref(reference_name) }}
+FROM  {{ ref(reference_name) }})
+
+SELECT DISTINCT * FROM BASE
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_transactions_sourced_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_transactions_sourced_rollup.sql
@@ -1,19 +1,20 @@
 {% macro create_stg_frakture_global_message_email_transactions_sourced_rollup(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
 SELECT SAFE_CAST(message_id AS STRING) AS message_id,    
-    SAFE_CAST(attributed_revenue AS numeric) AS total_revenue,
-    SAFE_CAST(attributed_transactions AS int) AS total_gifts,
-    SAFE_CAST(origin_person_count AS int) AS total_donors,  -- doesn't seem available in Frakture ad_summary tables
-    SAFE_CAST(attributed_revenue - attributed_recurring_revenue AS numeric) AS one_time_revenue,
-    SAFE_CAST(attributed_transactions - attributed_recurring_transactions  AS int) AS one_time_gifts,
-    SAFE_CAST(NULL  AS numeric) AS new_monthly_revenue, -- doesn't seem available in Frakture ad_summary tables
-    SAFE_CAST(NULL  AS int) AS new_monthly_gifts, -- doesn't seem available in Frakture ad_summary tables
-    SAFE_CAST(attributed_recurring_revenue  AS numeric) AS total_monthly_revenue,
-    SAFE_CAST(attributed_recurring_transactions  AS int) AS total_monthly_gifts,
-    SAFE_CAST(campaign  AS STRING) AS campaign,
-    SAFE_CAST(campaign_label  AS STRING) AS campaign_label,
-    SAFE_CAST(message_set AS STRING) AS message_set,
-    SAFE_CAST(audience  AS STRING) AS audience,
-    SAFE_CAST(appeal AS STRING) AS appeal
- FROM  {{ ref(reference_name) }} 
+    SUM(SAFE_CAST(attributed_revenue AS numeric)) AS total_revenue,
+    SUM(SAFE_CAST(attributed_transactions AS int)) AS total_gifts,
+    SUM(SAFE_CAST(origin_person_count AS int)) AS total_donors,  -- doesn't seem available in Frakture ad_summary tables
+    SUM(SAFE_CAST(attributed_revenue - attributed_recurring_revenue AS numeric)) AS one_time_revenue,
+    SUM(SAFE_CAST(attributed_transactions - attributed_recurring_transactions  AS int)) AS one_time_gifts,
+    SUM(SAFE_CAST(NULL  AS numeric)) AS new_monthly_revenue, -- doesn't seem available in Frakture ad_summary tables
+    SUM(SAFE_CAST(NULL  AS int)) AS new_monthly_gifts, -- doesn't seem available in Frakture ad_summary tables
+    SUM(SAFE_CAST(attributed_recurring_revenue  AS numeric)) AS total_monthly_revenue,
+    SUM(SAFE_CAST(attributed_recurring_transactions  AS int)) AS total_monthly_gifts,
+    MIN(SAFE_CAST(campaign  AS STRING)) AS campaign,
+    MIN((campaign_label  AS STRING)) AS campaign_label,
+    MIN((message_set AS STRING)) AS message_set,
+    MIN(SAFE_CAST(audience  AS STRING)) AS audience,
+    MIN(SAFE_CAST(appeal AS STRING)) AS appeal
+ FROM  {{ ref(reference_name) }}
+ GROUP BY 1 
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_unsubscribes_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_unsubscribes_rollup.sql
@@ -1,6 +1,7 @@
 {% macro create_stg_frakture_global_message_email_unsubscribes_rollup(
     reference_name='stg_frakture_global_message_email_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
- SAFE_CAST(unsubscribes AS INT) AS unsubscribes
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,
+ SUM(SAFE_CAST(unsubscribes AS INT)) AS unsubscribes
 FROM {{ ref(reference_name) }} 
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_campaigns.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_campaigns.sql
@@ -1,9 +1,11 @@
 {% macro create_stg_frakture_global_message_paidmedia_campaigns(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(campaign_id AS STRING) AS campaign_id
+WITH BASE AS (SELECT SAFE_CAST(campaign_id AS STRING) AS campaign_id
   , SAFE_CAST(message_id AS STRING) AS message_id
   , SAFE_CAST(channel AS STRING) AS channel
   , SAFE_CAST(type AS STRING) AS channel_type
   , SAFE_CAST(campaign_name AS STRING) AS campaign_name
-FROM {{ ref(reference_name) }}
+FROM {{ ref(reference_name) }})
+
+SELECT DISTINCT * FROM BASE
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_clicks_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_clicks_daily_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_paidmedia_clicks_daily_rollup(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(ad_summary_by_date.clicks AS INT) AS total_clicks,
-  SAFE_CAST(ad_summary_by_date.clicks AS INT) AS unique_clicks
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
+  MIN(SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP)) AS date_timestamp,
+  SUM(SAFE_CAST(ad_summary_by_date.clicks AS INT)) AS total_clicks,
+  SUM(SAFE_CAST(ad_summary_by_date.clicks AS INT)) AS unique_clicks
 FROM {{ ref(reference_name) }} ad_summary_by_date
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_impressions_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_impressions_daily_rollup.sql
@@ -1,7 +1,8 @@
 {% macro create_stg_frakture_global_message_paidmedia_impressions_daily_rollup(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(ad_summary_by_date.impressions AS INT) AS total_impressions,
-  SAFE_CAST(NULL AS INT) AS unique_impressions
+SELECT SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
+  SUM(SAFE_CAST(ad_summary_by_date.impressions AS INT)) AS total_impressions,
+  SUM(SAFE_CAST(NULL AS INT) AS unique_impressions)
 FROM {{ ref(reference_name) }} ad_summary_by_date
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_sources_campaigns_messages_bridge.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_sources_campaigns_messages_bridge.sql
@@ -1,7 +1,8 @@
 {% macro create_stg_frakture_global_message_paidmedia_sources_campaigns_messages_bridge(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-       SAFE_CAST(primary_source_code AS STRING) AS source_code,       
-       SAFE_CAST(campaign_id AS STRING) AS campaign_id
+SELECT SAFE_CAST(message_id AS STRING) AS message_id,
+       MIN(SAFE_CAST(primary_source_code AS STRING)) AS source_code,       
+       MIN(SAFE_CAST(campaign_id AS STRING)) AS campaign_id
 FROM  {{ ref(reference_name) }}
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_spends_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_spends_daily_rollup.sql
@@ -1,7 +1,8 @@
 {% macro create_stg_frakture_global_message_paidmedia_spends_daily_rollup(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT  SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,
-  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(ad_summary_by_date.spend AS NUMERIC) AS spend_amount
+SELECT SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,
+  MIN(SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP)) AS date_timestamp,
+  SUM(SAFE_CAST(ad_summary_by_date.spend AS NUMERIC)) AS spend_amount
 FROM  {{ ref(reference_name) }} ad_summary_by_date
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_subscribes_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_subscribes_daily_rollup.sql
@@ -1,7 +1,8 @@
 {% macro create_stg_frakture_global_message_paidmedia_subscribes_daily_rollup(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT  SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,
-  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(NULL AS INTEGER) AS subscribes
+SELECT SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,
+  MIN(SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP)) AS date_timestamp,
+  SUM(SAFE_CAST(NULL AS INTEGER)) AS subscribes
 FROM  {{ ref(reference_name) }} ad_summary_by_date
+GROUP BY 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_transactions_sourced_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_transactions_sourced_rollup.sql
@@ -1,18 +1,20 @@
 {% macro create_stg_frakture_global_message_paidmedia_transactions_sourced_rollup(
     reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT SAFE_CAST(ad_summary.message_id AS STRING) AS message_id,    SAFE_CAST(ad_summary.date AS TIMESTAMP) AS date_timestamp,
-    SAFE_CAST(ad_summary.attributed_revenue AS numeric) AS total_revenue,
-    SAFE_CAST(ad_summary.attributed_transactions AS int) AS total_gifts,
-    SAFE_CAST(ad_summary.origin_person_count AS int) AS total_donors,  -- doesn't seem available in Frakture ad_summary tables
-    SAFE_CAST(ad_summary.attributed_revenue - ad_summary.attributed_recurring_revenue AS numeric) AS one_time_revenue,
-    SAFE_CAST(ad_summary.attributed_transactions - ad_summary.attributed_recurring_transactions  AS int) AS one_time_gifts,
-    SAFE_CAST(NULL  AS numeric) AS new_monthly_revenue, -- doesn't seem available in Frakture ad_summary tables
-    SAFE_CAST(NULL  AS int) AS new_monthly_gifts, -- doesn't seem available in Frakture ad_summary tables
-    SAFE_CAST(ad_summary.attributed_recurring_revenue  AS numeric) AS total_monthly_revenue,
-    SAFE_CAST(ad_summary.attributed_recurring_transactions  AS int) AS total_monthly_gifts,
-    SAFE_CAST(ad_summary.campaign  AS STRING) AS campaign,
-    SAFE_CAST(ad_summary.campaign_label  AS STRING) AS campaign_label,
-    SAFE_CAST(ad_summary.audience  AS STRING) AS audience,
-    SAFE_CAST(ad_summary.appeal AS STRING) AS appeal
+SELECT SAFE_CAST(ad_summary.message_id AS STRING) AS message_id,    
+    MIN(SAFE_CAST(ad_summary.date AS TIMESTAMP)) AS date_timestamp,
+    SUM(SAFE_CAST(ad_summary.attributed_revenue AS numeric)) AS total_revenue,
+    SUM(SAFE_CAST(ad_summary.attributed_transactions AS int)) AS total_gifts,
+    SUM(SAFE_CAST(ad_summary.origin_person_count AS int)) AS total_donors,  -- doesn't seem available in Frakture ad_summary tables
+    SUM(SAFE_CAST(ad_summary.attributed_revenue - ad_summary.attributed_recurring_revenue AS numeric)) AS one_time_revenue,
+    SUM(SAFE_CAST(ad_summary.attributed_transactions - ad_summary.attributed_recurring_transactions  AS int)) AS one_time_gifts,
+    SUM(SAFE_CAST(NULL  AS numeric)) AS new_monthly_revenue, -- doesn't seem available in Frakture ad_summary tables
+    SUM(SAFE_CAST(NULL  AS int)) AS new_monthly_gifts, -- doesn't seem available in Frakture ad_summary tables
+    SUM(SAFE_CAST(ad_summary.attributed_recurring_revenue  AS numeric)) AS total_monthly_revenue,
+    SUM(SAFE_CAST(ad_summary.attributed_recurring_transactions  AS int)) AS total_monthly_gifts,
+    MIN(SAFE_CAST(ad_summary.campaign  AS STRING)) AS campaign,
+    MIN(SAFE_CAST(ad_summary.campaign_label  AS STRING)) AS campaign_label,
+    MIN(SAFE_CAST(ad_summary.audience  AS STRING)) AS audience,
+    MIN(SAFE_CAST(ad_summary.appeal AS STRING)) AS appeal
  FROM  {{ ref(reference_name) }} ad_summary
+ GROUP BY 1
 {% endmacro %}


### PR DESCRIPTION
`distinct Message ID` was not working in the global message email or paid media staging modes 

there were duplicate message Ids all over

so I incorporated grouping by message ID and summing KPIs for the staging tables instead.

`dbt compile` works well, and I tested it in the arc mercy corps repo