### PR TITLE
added source freshness where possible

### DIFF
--- a/sources/frakture_global_message_email.yml
+++ b/sources/frakture_global_message_email.yml
@@ -5,5 +5,9 @@ sources:
     schema: src_frakture
     tables:
       - name: global_message_summary_by_date
+        freshness: 
+          warn_after: {count: 2, period: day}
+          error_after: {count: 7, period: day}
+        loaded_at_field: cast(publish_date as timestamp)
       - name: global_message
     

--- a/sources/frakture_global_message_paidmedia.yml
+++ b/sources/frakture_global_message_paidmedia.yml
@@ -5,4 +5,8 @@ sources:
     schema: src_frakture
     tables:
       - name: global_message_summary_by_date
+        freshness: 
+          warn_after: {count: 2, period: day}
+          error_after: {count: 7, period: day}
+        loaded_at_field: cast(publish_date as timestamp)
       - name: global_message

--- a/sources/frakture_global_transactions.yml
+++ b/sources/frakture_global_transactions.yml
@@ -5,3 +5,7 @@ sources:
     schema: src_frakture
     tables:
       - name: transaction_summary
+        freshness: 
+          warn_after: {count: 2, period: day}
+          error_after: {count: 7, period: day}
+        loaded_at_field: cast(ts as timestamp)


### PR DESCRIPTION
tested in mercy-corps and it warned properly!

future goal will be to have frakture populate their table `frakture_warehouse_source` and use only that as guideline for source freshness, but they haven't populated that table for us. ticket to frakture support in progress.