### PR TITLE
ARC-1242 add on-run-end to dbt project

### DIFF
--- a/utils/first_run_dbt_project_and_profiles_fixer.py
+++ b/utils/first_run_dbt_project_and_profiles_fixer.py
@@ -62,7 +62,7 @@ Enter y for (y)es and n for (n)o. (We recommend y):
 """
 
 
-def update_dbt_project(dbt_project, project_name, project_name_underscore, yaml):
+def update_dbt_project(dbt_project, project_name, project_name_underscore, yaml, dbt_artifacts_choice):
     """
     Updates the `dbt_project.yml` file with the project name, removes the `my_new_project` model, adds a `database` variable and adds the standard model directory structure.
 
@@ -94,6 +94,8 @@ def update_dbt_project(dbt_project, project_name, project_name_underscore, yaml)
             'materialized': 'table',
             'schema': 'marts'}}
     dbt_project_yml['models'][project_name_underscore] = standard_models
+    if dbt_artifacts_choice == 'y':
+        dbt_project_yml['on-run-end'] = ["{% if target.name == 'default' %}{{ dbt_artifacts.upload_results(results) }}{% endif %}"]
     copy_choice = inplace_or_copy("dbt_project")
     file, extension = path.splitext(dbt_project)
     with open(file + copy_choice + extension, 'w') as f:
@@ -196,7 +198,7 @@ def get_dbt_artifacts_with_version():
     return package_with_version
 
 
-def write_packages_yml(dbt_packages_path, active_branch_name, yaml):
+def write_packages_yml(dbt_packages_path, active_branch_name, yaml, dbt_artifacts_choice):
     """
     Write a 'packages.yml' file to the given `dbt_packages_path` with the current revision set to the given
     `active_branch_name`. The `yaml` object is used to dump the `packages_dict` to the file. If a 'packages.yml'
@@ -207,9 +209,6 @@ def write_packages_yml(dbt_packages_path, active_branch_name, yaml):
         active_branch_name=active_branch_name))
     revision = revision_choice if revision_choice else active_branch_name
     packages_dict['packages'][1]['revision'] = revision
-    dbt_artifacts_choice = None
-    while dbt_artifacts_choice not in ('y', 'n'):
-        dbt_artifacts_choice = input(dbt_artifacts_choice_helptext)
     if dbt_artifacts_choice == 'y':
         packages_dict['packages'].append(get_dbt_artifacts_with_version())
     if not path.exists(dbt_packages_path):
@@ -257,11 +256,14 @@ def main():
     yaml = ruamel.yaml.YAML()
     yaml.indent(mapping=4, sequence=4, offset=2)
     yaml.preserve_quotes = True
-    update_dbt_project(dbt_project_path, project_id, project_id_underscore, yaml)
+    dbt_artifacts_choice = None
+    while dbt_artifacts_choice not in ('y', 'n'):
+        dbt_artifacts_choice = input(dbt_artifacts_choice_helptext)
+    update_dbt_project(dbt_project_path, project_id, project_id_underscore, yaml, dbt_artifacts_choice)
     dbt_base_path = path.dirname(dbt_project_path)
     dbt_packages_path = path.join(dbt_base_path, 'packages.yml')
     active_branch_name = get_active_branch_name()
-    write_packages_yml(dbt_packages_path, active_branch_name, yaml)
+    write_packages_yml(dbt_packages_path, active_branch_name, yaml, dbt_artifacts_choice)
     dbt_example_path = path.join(dbt_base_path, 'models', 'example')
     if path.exists(dbt_example_path):
         if input("\nCan I delete 'models/example'? (y/n)\n") == 'y':


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below.

Ran successfully in ARC-Vera:
![Screenshot 2023-02-08 at 10 14 13 AM](https://user-images.githubusercontent.com/16624855/217571255-c2386127-15b8-4386-956f-adc286875355.png)



- [x] check in dbt that client package successfully runs `dbt deps`, `dbt compile`, and `dbt run`; screenshot this page
![Screenshot 2023-02-08 at 10 19 30 AM](https://user-images.githubusercontent.com/16624855/217572034-2afd11e5-3225-40f7-a5b2-e42f364a42fd.png)


- [x] query the resulting staging model in bigquery (or by previewing mart in dbt cloud, or your IDE); screenshot this
![Screenshot 2023-02-08 at 10 18 18 AM](https://user-images.githubusercontent.com/16624855/217571817-2f512efd-3536-4d39-a715-ea2e11fe75ad.png)

- [x] If exists, link bug issue and jira tickets to PR
https://github.com/bsd/dbt-arc-functions/issues/145
https://bluestate.atlassian.net/browse/ARC-1248
