### PR TITLE
ARC-1274 Add docs to frakture global message email jobs

### DIFF
--- a/documentation/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.yml
+++ b/documentation/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.yml
@@ -1,8 +1,3 @@
-# TODO Write documentation for stg_frakture_global_message_email_jobs [documentation]
-#  Github main branch URL:
-#  https://github.com/bsd/dbt-arc-functions/blob/main/documentation/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.yml
-#  Where to find in dbt-arc-functions local directory:
-#  documentation/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.yml
 version: 2
 
 models:
@@ -10,32 +5,32 @@ models:
     description: Please replace this default description.
     columns:
       - name: message_id
-        description: ""
+        description: "Unique ID for email from Frakture."
 
       - name: from_name
-        description: ""
+        description: "Name that appears in 'From' line on email client. NOT the email address, that is from_email."
 
       - name: from_email
-        description: ""
+        description: "Email address that appears in 'From' line on email client."
 
       - name: best_guess_timestamp
-        description: ""
+        description: "Timestamp from Frakture's 'publish_date' field."
 
       - name: scheduled_timestamp
-        description: ""
+        description: "Frakture does not provide this, so set to NULL"
 
       - name: pickup_timestamp
-        description: ""
+        description: "Frakture does not provide this, so set to NULL"
 
       - name: delivered_timestamp
-        description: ""
+        description: "Frakture does not provide this, so set to NULL"
 
       - name: email_name
-        description: ""
+        description: "Internal name for the email, from Frakture's 'label' field."
 
       - name: email_subject
-        description: ""
+        description: "The subject line an end-user will see in their email client."
 
       - name: source_code
-        description: ""
+        description: "Source Code associated with this particular email. From Frakture's 'final_primary_source_code' field."
 


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug).
Ran against the standard dashboard:
![Screenshot 2023-02-10 at 12 01 03 PM](https://user-images.githubusercontent.com/16624855/218151588-d13c8edf-42d1-4869-828d-8aafc2668982.png)

- [x] check in dbt that client package successfully runs `dbt docs generate`
![Screenshot 2023-02-10 at 12 02 22 PM](https://user-images.githubusercontent.com/16624855/218151891-6e635da1-9ddc-406f-be08-98d77bf77f17.png)

- [x] If exists, link bug issue and jira tickets to PR
https://bluestate.atlassian.net/browse/ARC-1274
