### PR TITLE
ARC-1409 add sqlfmt_linter

### DIFF
--- a/.github/workflows/sqlfmt_linter.yml
+++ b/.github/workflows/sqlfmt_linter.yml
@@ -1,0 +1,30 @@
+name: sqlfmt
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install 'shandy-sqlfmt[jinjafmt]'
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run sqlfmt
+      run: |
+        sqlfmt --diff .

--- a/.github/workflows/sqlfmt_linter.yml
+++ b/.github/workflows/sqlfmt_linter.yml
@@ -1,4 +1,4 @@
-name: sqlfmt
+name: sqlfmt linter
 
 on:
   push:

--- a/macros/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.sql
+++ b/macros/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.sql
@@ -1,24 +1,25 @@
 {% macro create_mart_combined_email_paidmedia_daily_revenue_performance(
-    reference_0_name='mart_email_performance_with_revenue',
-    reference_1_name='mart_paidmedia_daily_revenue_performance') %}
-SELECT 
-    TIMESTAMP_TRUNC(best_guess_timestamp,DAY) as date_timestamp,
-    'email' AS channel,
+    reference_0_name="mart_email_performance_with_revenue",
+    reference_1_name="mart_paidmedia_daily_revenue_performance"
+) %}
+select
+    timestamp_trunc(best_guess_timestamp, day) as date_timestamp,
+    'email' as channel,
     best_guess_entity,
-    SUM(COALESCE(total_revenue,0)) AS total_revenue,
-    SUM(COALESCE(total_gifts,0)) AS total_gifts
-FROM {{ ref(reference_0_name) }}
-WHERE TIMESTAMP_TRUNC(best_guess_timestamp,DAY) IS NOT NULL
-GROUP BY 1,2, 3
-UNION ALL
-SELECT
+    sum(coalesce(total_revenue, 0)) as total_revenue,
+    sum(coalesce(total_gifts, 0)) as total_gifts
+from {{ ref(reference_0_name) }}
+where timestamp_trunc(best_guess_timestamp, day) is not null
+group by 1, 2, 3
+union all
+select
     date_timestamp,
     channel,
     best_guess_entity,
-    SUM(COALESCE(total_revenue,0)) AS total_revenue,
-    SUM(COALESCE(total_gifts,0)) AS total_gifts
-FROM {{ ref(reference_1_name) }}
-WHERE date_timestamp IS NOT NULL
-GROUP BY 1,2, 3
+    sum(coalesce(total_revenue, 0)) as total_revenue,
+    sum(coalesce(total_gifts, 0)) as total_gifts
+from {{ ref(reference_1_name) }}
+where date_timestamp is not null
+group by 1, 2, 3
 
 {% endmacro %}

--- a/macros/email/marts/mart_email_performance_with_revenue.sql
+++ b/macros/email/marts/mart_email_performance_with_revenue.sql
@@ -1,16 +1,18 @@
 {% macro create_mart_email_performance_with_revenue(
-    jobs='stg_email_jobs_unioned',
-    campaigns='stg_email_campaigns_rollup_unioned',
-    campaign_dates='stg_email_campaign_dates_rollup_unioned',
-    bounces='stg_email_bounces_rollup_unioned',
-    clicks='stg_email_clicks_rollup_unioned',
-    opens='stg_email_opens_rollup_unioned',
-    actions='stg_email_actions_rollup_unioned',
-    complaints='stg_email_complaints_rollup_unioned',
-    recipients='stg_email_recipients_rollup_unioned',
-    transactions='stg_email_transactions_sourced_rollup_unioned',
-    unsubscribes='stg_email_unsubscribes_rollup_unioned') %}
-SELECT jobs.message_id,
+    jobs="stg_email_jobs_unioned",
+    campaigns="stg_email_campaigns_rollup_unioned",
+    campaign_dates="stg_email_campaign_dates_rollup_unioned",
+    bounces="stg_email_bounces_rollup_unioned",
+    clicks="stg_email_clicks_rollup_unioned",
+    opens="stg_email_opens_rollup_unioned",
+    actions="stg_email_actions_rollup_unioned",
+    complaints="stg_email_complaints_rollup_unioned",
+    recipients="stg_email_recipients_rollup_unioned",
+    transactions="stg_email_transactions_sourced_rollup_unioned",
+    unsubscribes="stg_email_unsubscribes_rollup_unioned"
+) %}
+select
+    jobs.message_id,
     jobs.from_name,
     jobs.from_email,
     jobs.best_guess_timestamp,
@@ -24,13 +26,18 @@ SELECT jobs.message_id,
     jobs.source_code,
     campaigns.crm_entity,
     campaigns.source_code_entity,
-    case when (campaigns.crm_entity is not null and campaigns.source_code_entity is not null)
-          then CONCAT(campaigns.crm_entity,'-', campaigns.source_code_entity)
-          else COALESCE(campaigns.crm_entity,campaigns.source_code_entity) END
-          AS best_guess_entity,
+    case
+        when
+            (
+                campaigns.crm_entity is not null
+                and campaigns.source_code_entity is not null
+            )
+        then concat(campaigns.crm_entity, '-', campaigns.source_code_entity)
+        else coalesce(campaigns.crm_entity, campaigns.source_code_entity)
+    end as best_guess_entity,
     campaigns.audience,
     campaigns.campaign_category,
-    COALESCE(campaigns.campaign_name, campaign_dates.campaign_name) as campaign_name,
+    coalesce(campaigns.campaign_name, campaign_dates.campaign_name) as campaign_name,
     campaigns.recurtype,
     recipients.recipients,
     opens.opens,
@@ -52,25 +59,17 @@ SELECT jobs.message_id,
     transactions.new_monthly_gifts,
     transactions.total_monthly_revenue,
     transactions.total_monthly_gifts
-FROM {{ ref(jobs) }} jobs
-FULL JOIN {{ ref(bounces) }} bounces
-USING (message_id)
-FULL JOIN {{ ref(campaigns) }} campaigns
-USING (message_id)
-FULL JOIN {{ ref(clicks) }} clicks
-USING (message_id)
-FULL JOIN {{ ref(actions) }} actions
-USING (message_id)
-FULL JOIN {{ ref(complaints) }} complaints
-USING (message_id)
-FULL JOIN {{ ref(opens) }} opens
-USING (message_id)
-FULL JOIN {{ ref(recipients) }}  recipients
-USING (message_id)
-FULL JOIN {{ ref(transactions) }}  transactions
-USING (message_id)
-FULL JOIN {{ ref(unsubscribes) }} unsubscribes
-USING (message_id)
-FULL JOIN {{ ref(campaign_dates)}} campaign_dates
-ON campaigns.campaign_name = campaign_dates.campaign_name
+from {{ ref(jobs) }} jobs
+full join {{ ref(bounces) }} bounces using (message_id)
+full join {{ ref(campaigns) }} campaigns using (message_id)
+full join {{ ref(clicks) }} clicks using (message_id)
+full join {{ ref(actions) }} actions using (message_id)
+full join {{ ref(complaints) }} complaints using (message_id)
+full join {{ ref(opens) }} opens using (message_id)
+full join {{ ref(recipients) }} recipients using (message_id)
+full join {{ ref(transactions) }} transactions using (message_id)
+full join {{ ref(unsubscribes) }} unsubscribes using (message_id)
+full join
+    {{ ref(campaign_dates) }} campaign_dates
+    on campaigns.campaign_name = campaign_dates.campaign_name
 {% endmacro %}

--- a/macros/email/staging/stg_email_actions_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_actions_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_actions_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_actions_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_actions_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_bounces_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_bounces_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_bounces_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_bounces_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_bounces_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_campaign_dates_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_campaign_dates_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_campaign_dates_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_campaign_dates_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_campaign_dates_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_campaigns_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_campaigns_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_campaigns_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_campaigns_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_campaigns_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_clicks_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_clicks_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_clicks_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_clicks_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_clicks_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_complaints_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_complaints_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_complaints_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_complaints_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_complaints_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_jobs_unioned.sql
+++ b/macros/email/staging/stg_email_jobs_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_jobs_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_jobs$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_jobs$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_opens_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_opens_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_opens_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_opens_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_opens_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_recipients_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_recipients_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_recipients_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_recipients_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_recipients_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_transactions_sourced_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_transactions_sourced_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_transactions_sourced_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_transactions_sourced_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_transactions_sourced_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email/staging/stg_email_unsubscribes_rollup_unioned.sql
+++ b/macros/email/staging/stg_email_unsubscribes_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_unsubscribes_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_email_unsubscribes_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_email_unsubscribes_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/marts/mart_email_deliverability_by_domain_and_date.sql
+++ b/macros/email_deliverability/marts/mart_email_deliverability_by_domain_and_date.sql
@@ -1,62 +1,84 @@
 {% macro create_mart_email_deliverability_by_domain_and_date(
-    jobs='stg_email_deliverability_person_jobs_distinct_unioned',
-    bounces='stg_email_deliverability_person_bounces_daily_rollup_unioned',
-    clicks='stg_email_deliverability_person_clicks_daily_rollup_unioned',
-    opens='stg_email_deliverability_person_opens_daily_rollup_unioned',
-    actions='stg_email_deliverability_person_actions_daily_rollup_unioned',
-    recipients='stg_email_deliverability_person_recipients_daily_rollup_unioned',
-    unsubscribes='stg_email_deliverability_person_unsubscribes_daily_rollup_unioned') %}
-SELECT
+    jobs="stg_email_deliverability_person_jobs_distinct_unioned",
+    bounces="stg_email_deliverability_person_bounces_daily_rollup_unioned",
+    clicks="stg_email_deliverability_person_clicks_daily_rollup_unioned",
+    opens="stg_email_deliverability_person_opens_daily_rollup_unioned",
+    actions="stg_email_deliverability_person_actions_daily_rollup_unioned",
+    recipients="stg_email_deliverability_person_recipients_daily_rollup_unioned",
+    unsubscribes="stg_email_deliverability_person_unsubscribes_daily_rollup_unioned"
+) %}
+select
     jobs.sent_date,
     jobs.message_id,
     jobs.email_domain,
-    CASE WHEN lower(jobs.email_domain) LIKE 'live.%' THEN 'Microsoft' 
-    WHEN lower(jobs.email_domain) LIKE 'hotmail.%' THEN 'Microsoft' 
-    WHEN lower(jobs.email_domain) LIKE 'outlook.%' THEN 'Microsoft' 
-    WHEN lower(jobs.email_domain) LIKE 'msn.%' THEN 'Microsoft'
-    WHEN lower(jobs.email_domain) LIKE 'gmail.com' THEN 'Google'
-    WHEN lower(jobs.email_domain) LIKE 'googlemail.com' THEN 'Google'
-    WHEN lower(jobs.email_domain) LIKE 'google.com' THEN 'Google'  
-    WHEN lower(jobs.email_domain) LIKE 'gmail.com' THEN 'Google'
-    WHEN lower(jobs.email_domain) LIKE 'yahoo.%' THEN 'Yahoo'
-    WHEN lower(jobs.email_domain) LIKE 'myyahoo.%' THEN 'Yahoo'
-    WHEN lower(jobs.email_domain)LIKE 'me.com' THEN 'Apple'
-    WHEN lower(jobs.email_domain)LIKE 'apple.com' THEN 'Apple'
-    WHEN lower(jobs.email_domain) LIKE 'icloud.com' THEN 'Apple'
-    WHEN lower(jobs.email_domain) LIKE 'mac.com' THEN 'Apple'
-    ELSE 'Other'
-    END AS domain_category,
+    case
+        when lower(jobs.email_domain) like 'live.%'
+        then 'Microsoft'
+        when lower(jobs.email_domain) like 'hotmail.%'
+        then 'Microsoft'
+        when lower(jobs.email_domain) like 'outlook.%'
+        then 'Microsoft'
+        when lower(jobs.email_domain) like 'msn.%'
+        then 'Microsoft'
+        when lower(jobs.email_domain) like 'gmail.com'
+        then 'Google'
+        when lower(jobs.email_domain) like 'googlemail.com'
+        then 'Google'
+        when lower(jobs.email_domain) like 'google.com'
+        then 'Google'
+        when lower(jobs.email_domain) like 'gmail.com'
+        then 'Google'
+        when lower(jobs.email_domain) like 'yahoo.%'
+        then 'Yahoo'
+        when lower(jobs.email_domain) like 'myyahoo.%'
+        then 'Yahoo'
+        when lower(jobs.email_domain) like 'me.com'
+        then 'Apple'
+        when lower(jobs.email_domain) like 'apple.com'
+        then 'Apple'
+        when lower(jobs.email_domain) like 'icloud.com'
+        then 'Apple'
+        when lower(jobs.email_domain) like 'mac.com'
+        then 'Apple'
+        else 'Other'
+    end as domain_category,
     recipients.recipients,
     opens.opens,
     clicks.clicks,
     actions.actions,
-    (bounces.soft_bounces + bounces.hard_bounces) AS total_bounces,
+    (bounces.soft_bounces + bounces.hard_bounces) as total_bounces,
     bounces.soft_bounces,
     bounces.hard_bounces,
     unsubscribes.unsubscribes
-FROM {{ ref(jobs) }} jobs
-LEFT JOIN {{ ref(bounces) }} bounces
-ON jobs.message_id = bounces.message_id
-AND jobs.sent_date = bounces.sent_date
-AND jobs.email_domain = bounces.email_domain
-LEFT JOIN {{ ref(clicks) }} clicks
-ON jobs.message_id = clicks.message_id
-AND jobs.sent_date = clicks.sent_date
-AND jobs.email_domain = clicks.email_domain
-LEFT JOIN {{ ref(actions) }} actions
-ON jobs.message_id = actions.message_id
-AND jobs.sent_date = actions.sent_date
-AND jobs.email_domain = actions.email_domain
-LEFT JOIN {{ ref(opens) }} opens
-ON jobs.message_id = opens.message_id
-AND jobs.sent_date = opens.sent_date
-AND jobs.email_domain = opens.email_domain
-LEFT JOIN {{ ref(recipients) }}  recipients
-ON jobs.message_id = recipients.message_id
-AND jobs.sent_date = recipients.sent_date
-AND jobs.email_domain = recipients.email_domain
-LEFT JOIN {{ ref(unsubscribes) }} unsubscribes
-ON jobs.message_id = unsubscribes.message_id
-AND jobs.sent_date = unsubscribes.sent_date
-AND jobs.email_domain = unsubscribes.email_domain
+from {{ ref(jobs) }} jobs
+left join
+    {{ ref(bounces) }} bounces
+    on jobs.message_id = bounces.message_id
+    and jobs.sent_date = bounces.sent_date
+    and jobs.email_domain = bounces.email_domain
+left join
+    {{ ref(clicks) }} clicks
+    on jobs.message_id = clicks.message_id
+    and jobs.sent_date = clicks.sent_date
+    and jobs.email_domain = clicks.email_domain
+left join
+    {{ ref(actions) }} actions
+    on jobs.message_id = actions.message_id
+    and jobs.sent_date = actions.sent_date
+    and jobs.email_domain = actions.email_domain
+left join
+    {{ ref(opens) }} opens
+    on jobs.message_id = opens.message_id
+    and jobs.sent_date = opens.sent_date
+    and jobs.email_domain = opens.email_domain
+left join
+    {{ ref(recipients) }} recipients
+    on jobs.message_id = recipients.message_id
+    and jobs.sent_date = recipients.sent_date
+    and jobs.email_domain = recipients.email_domain
+left join
+    {{ ref(unsubscribes) }} unsubscribes
+    on jobs.message_id = unsubscribes.message_id
+    and jobs.sent_date = unsubscribes.sent_date
+    and jobs.email_domain = unsubscribes.email_domain
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_actions_daily_rollup_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_actions_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_actions_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_actions_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_actions_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_bounces_daily_rollup_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_bounces_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_bounces_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_bounces_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_bounces_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_clicks_daily_rollup_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_clicks_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_clicks_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_clicks_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_clicks_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_jobs_distinct_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_jobs_distinct_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_jobs_distinct_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_jobs_distinct$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_jobs_distinct$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_opens_daily_rollup_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_opens_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_opens_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_opens_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_opens_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_recipients_daily_rollup_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_recipients_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_recipients_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_recipients_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_recipients_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_deliverability/staging/stg_email_deliverability_person_unsubscribes_daily_rollup_unioned.sql
+++ b/macros/email_deliverability/staging/stg_email_deliverability_person_unsubscribes_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_email_deliverability_person_unsubscribes_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_person_unsubscribes_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_person_unsubscribes_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/email_listhealth/marts/mart_email_listhealth_by_month.sql
+++ b/macros/email_listhealth/marts/mart_email_listhealth_by_month.sql
@@ -1,16 +1,16 @@
 {% macro create_mart_email_listhealth_by_month(
-    reference_name='stg_email_listhealth_with_prev_delivered'
+    reference_name="stg_email_listhealth_with_prev_delivered"
 ) %}
-SELECT
-date_month,
-max_recipients,
-max_delivered,
-CAST(delivered_prev_month as INT) as delivered_prev_month,
-CAST(max_delivered AS INT) - CAST(delivered_prev_month as INT) as diff_delivered_prev_month,
-total_unsubscribes,
-total_hard_bounces,
-total_complaints 
-FROM  {{ ref(reference_name) }} mart_email
+select
+    date_month,
+    max_recipients,
+    max_delivered,
+    cast(delivered_prev_month as int) as delivered_prev_month,
+    cast(max_delivered as int)
+    - cast(delivered_prev_month as int) as diff_delivered_prev_month,
+    total_unsubscribes,
+    total_hard_bounces,
+    total_complaints
+from {{ ref(reference_name) }} mart_email
 
 {% endmacro %}
-

--- a/macros/email_listhealth/staging/stg_email_listhealth_by_year_and_month.sql
+++ b/macros/email_listhealth/staging/stg_email_listhealth_by_year_and_month.sql
@@ -1,17 +1,15 @@
 {% macro create_stg_email_listhealth_year_and_month(
-    reference_name='mart_email_performance_with_revenue'
+    reference_name="mart_email_performance_with_revenue"
 ) %}
-SELECT
-extract(YEAR from best_guess_timestamp) as extract_year,
-extract(MONTH from best_guess_timestamp) as extract_month,
-MAX(recipients) AS max_recipients,
-MAX(recipients - total_bounces) AS max_delivered,
-SUM(unsubscribes) as total_unsubscribes,
-SUM(hard_bounces) as total_hard_bounces,
-SUM(complaints) as total_complaints
-FROM  {{ ref(reference_name) }} mart_email
-GROUP BY 1, 2
+select
+    extract(year from best_guess_timestamp) as extract_year,
+    extract(month from best_guess_timestamp) as extract_month,
+    max(recipients) as max_recipients,
+    max(recipients - total_bounces) as max_delivered,
+    sum(unsubscribes) as total_unsubscribes,
+    sum(hard_bounces) as total_hard_bounces,
+    sum(complaints) as total_complaints
+from {{ ref(reference_name) }} mart_email
+group by 1, 2
 
 {% endmacro %}
-
-

--- a/macros/email_listhealth/staging/stg_email_listhealth_by_year_and_month_concat.sql
+++ b/macros/email_listhealth/staging/stg_email_listhealth_by_year_and_month_concat.sql
@@ -1,27 +1,27 @@
 {% macro create_stg_email_listhealth_year_and_month_concat(
-    reference_name='stg_email_listhealth_by_year_and_month'
+    reference_name="stg_email_listhealth_by_year_and_month"
 ) %}
 
+with
+    base as (
+        select
+            concat(extract_year, '-', extract_month, '-01') as concat_date,
+            max_recipients,
+            max_delivered,
+            total_hard_bounces,
+            total_unsubscribes,
+            total_complaints
+        from {{ ref(reference_name) }} mart_email
+    )
 
-WITH BASE AS (SELECT
-CONCAT(extract_year,'-',extract_month,'-01') as concat_date,
-max_recipients,
-max_delivered,
-total_hard_bounces,
-total_unsubscribes,
-total_complaints
-FROM  {{ ref(reference_name) }} mart_email
-)
-
-SELECT
-SAFE_CAST(concat_date AS DATE) AS date_month,
-SAFE_CAST(max_recipients AS INT) AS max_recipients,
-SAFE_CAST(max_delivered AS INT) AS max_delivered,
-SAFE_CAST(total_unsubscribes AS INT) AS total_unsubscribes,
-SAFE_CAST(total_hard_bounces AS INT) AS total_hard_bounces,
-SAFE_CAST(total_complaints AS INT) AS total_complaints 
-FROM BASE
-WHERE concat_date IS NOT NULL
+select
+    safe_cast(concat_date as date) as date_month,
+    safe_cast(max_recipients as int) as max_recipients,
+    safe_cast(max_delivered as int) as max_delivered,
+    safe_cast(total_unsubscribes as int) as total_unsubscribes,
+    safe_cast(total_hard_bounces as int) as total_hard_bounces,
+    safe_cast(total_complaints as int) as total_complaints
+from base
+where concat_date is not null
 
 {% endmacro %}
-

--- a/macros/email_listhealth/staging/stg_email_listhealth_with_prev_delivered.sql
+++ b/macros/email_listhealth/staging/stg_email_listhealth_with_prev_delivered.sql
@@ -1,16 +1,14 @@
 {% macro create_stg_email_listhealth_with_prev_delivered(
-    reference_name='stg_email_listhealth_by_year_and_month_concat'
+    reference_name="stg_email_listhealth_by_year_and_month_concat"
 ) %}
-SELECT
-date_month,
-max_recipients,
-max_delivered,
-LAG(max_delivered) 
-OVER (ORDER BY date_month asc) AS delivered_prev_month,
-total_unsubscribes,
-total_hard_bounces,
-total_complaints 
-FROM  {{ ref(reference_name) }} mart_email
+select
+    date_month,
+    max_recipients,
+    max_delivered,
+    lag(max_delivered) over (order by date_month asc) as delivered_prev_month,
+    total_unsubscribes,
+    total_hard_bounces,
+    total_complaints
+from {{ ref(reference_name) }} mart_email
 
 {% endmacro %}
-

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_actions_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_actions_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_actions_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(actions AS INT)) AS actions
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(actions as int)) as actions
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_bounces_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_bounces_rollup.sql
@@ -1,11 +1,13 @@
 {% macro create_stg_frakture_actionkit_email_bounces_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(email_hard_bounces + email_soft_bounces AS INT)) AS total_bounces,
-  SUM(SAFE_CAST(email_blocked AS INT)) AS block_bounces,
-  SUM(SAFE_CAST(0 AS INT)) AS tech_bounces,
-  SUM(SAFE_CAST(email_soft_bounces AS INT)) AS soft_bounces,
-  SUM(SAFE_CAST(email_hard_bounces AS INT)) AS hard_bounces
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(email_hard_bounces + email_soft_bounces as int)) as total_bounces,
+    sum(safe_cast(email_blocked as int)) as block_bounces,
+    sum(safe_cast(0 as int)) as tech_bounces,
+    sum(safe_cast(email_soft_bounces as int)) as soft_bounces,
+    sum(safe_cast(email_hard_bounces as int)) as hard_bounces
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaign_dates.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaign_dates.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_campaign_dates(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT 
-  SAFE_CAST(publish_date as TIMESTAMP) as campaign_timestamp,
-  SAFE_CAST(campaign_label AS STRING) AS crm_campaign,
-  SAFE_CAST(campaign AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(publish_date as timestamp) as campaign_timestamp,
+    safe_cast(campaign_label as string) as crm_campaign,
+    safe_cast(campaign as string) as source_code_campaign
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaign_dates_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaign_dates_rollup.sql
@@ -1,9 +1,10 @@
 {% macro create_stg_frakture_actionkit_email_campaign_dates_rollup(
-    reference_name='stg_frakture_actionkit_email_campaign_dates') %}
-SELECT 
-  COALESCE(crm_campaign,source_code_campaign) AS campaign_name,
-  MIN(campaign_timestamp) as campaign_start_timestamp,
-  MAX(campaign_timestamp) as campaign_latest_timestamp
-FROM {{ ref(reference_name) }}
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_campaign_dates"
+) %}
+select
+    coalesce(crm_campaign, source_code_campaign) as campaign_name,
+    min(campaign_timestamp) as campaign_start_timestamp,
+    max(campaign_timestamp) as campaign_latest_timestamp
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaigns.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaigns.sql
@@ -1,14 +1,16 @@
 {% macro create_stg_frakture_actionkit_email_campaigns(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
 
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(bot_id as STRING) as crm_entity,
-  SAFE_CAST(account_prefix as STRING) as source_code_entity,
-  SAFE_CAST(audience as STRING) as audience,
-  SAFE_CAST(recurtype as STRING) as recurtype,
-  SAFE_CAST(COALESCE (tag,message_set) as STRING) as campaign_category,
-  SAFE_CAST(campaign_label AS STRING) AS crm_campaign,
-  SAFE_CAST(coalesce(campaign,campaign_label) AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(bot_id as string) as crm_entity,
+    safe_cast(account_prefix as string) as source_code_entity,
+    safe_cast(audience as string) as audience,
+    safe_cast(recurtype as string) as recurtype,
+    safe_cast(coalesce(tag, message_set) as string) as campaign_category,
+    safe_cast(campaign_label as string) as crm_campaign,
+    safe_cast(coalesce(campaign, campaign_label) as string) as source_code_campaign
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaigns_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_campaigns_rollup.sql
@@ -1,11 +1,13 @@
 {% macro create_stg_frakture_actionkit_email_campaigns_rollup(
-    reference_name='stg_frakture_actionkit_email_campaigns') %}
-SELECT DISTINCT message_id,
+    reference_name="stg_frakture_actionkit_email_campaigns"
+) %}
+select distinct
+    message_id,
     crm_entity,
     source_code_entity,
     audience,
     recurtype,
     campaign_category,
-    COALESCE(crm_campaign,source_code_campaign) AS campaign_name
-FROM {{ ref(reference_name) }}
+    coalesce(crm_campaign, source_code_campaign) as campaign_name
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_clicks_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_clicks_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_clicks_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(clicks AS INT)) AS clicks
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(clicks as int)) as clicks
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_complaints_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_complaints_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_complaints_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
-  SUM(SAFE_CAST(email_spam_complaints AS INT)) AS complaints
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(email_spam_complaints as int)) as complaints
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_jobs.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_jobs.sql
@@ -1,17 +1,20 @@
 {% macro create_stg_frakture_actionkit_email_jobs(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
 
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) as message_id, 
-    SAFE_CAST(from_name AS STRING) as from_name,
-    SAFE_CAST(from_email AS STRING) as from_email,
-    SAFE_CAST({{ dbt_date.convert_timezone('cast(publish_date as TIMESTAMP)') }} as TIMESTAMP) as best_guess_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) as scheduled_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) as pickup_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) as delivered_timestamp,
-    SAFE_CAST(label AS STRING) as email_name,
-    SAFE_CAST(subject AS STRING) as email_subject,
-    SAFE_CAST(final_primary_source_code AS STRING) as source_code
-FROM {{ ref(reference_name) }}
-
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(from_name as string) as from_name,
+    safe_cast(from_email as string) as from_email,
+    safe_cast(
+        {{ dbt_date.convert_timezone("cast(publish_date as TIMESTAMP)") }} as timestamp
+    ) as best_guess_timestamp,
+    safe_cast(null as timestamp) as scheduled_timestamp,
+    safe_cast(null as timestamp) as pickup_timestamp,
+    safe_cast(null as timestamp) as delivered_timestamp,
+    safe_cast(label as string) as email_name,
+    safe_cast(subject as string) as email_subject,
+    safe_cast(final_primary_source_code as string) as source_code
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_opens_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_opens_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_opens_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(email_opened AS INT)) AS opens
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(email_opened as int)) as opens
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_recipients_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_recipients_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_recipients_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(email_sent AS INT)) AS recipients
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(email_sent as int)) as recipients
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_summary_unioned.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_summary_unioned.sql
@@ -1,9 +1,11 @@
 {% macro create_stg_frakture_actionkit_email_summary_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^actionkit_[A-Za-z0-9]{3}_email_summary_by_date$',
-  is_source=True,
-  source_name='frakture_actionkit_email',
-  schema_to_search='src_frakture') 
-%}
-SELECT DISTINCT * FROM ({{ dbt_utils.union_relations(relations) }})
-WHERE message_id IS NOT NULL
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^actionkit_[A-Za-z0-9]{3}_email_summary_by_date$",
+    is_source=True,
+    source_name="frakture_actionkit_email",
+    schema_to_search="src_frakture",
+) %}
+select distinct *
+from ({{ dbt_utils.union_relations(relations) }})
+where message_id is not null
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_transactions_sourced_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_transactions_sourced_rollup.sql
@@ -1,36 +1,61 @@
 {% macro create_stg_frakture_actionkit_email_transactions_sourced_rollup(
-    email_summary='stg_frakture_actionkit_email_summary_unioned',
-    transactions='stg_frakture_actionkit_transactions_summary_unioned'
-    ) %}
+    email_summary="stg_frakture_actionkit_email_summary_unioned",
+    transactions="stg_frakture_actionkit_transactions_summary_unioned"
+) %}
 
-WITH GROUPED as (
-SELECT 
-    email_summary.message_id AS message_id,
-    SUM(SAFE_CAST(transactions.amount AS numeric)) AS total_revenue,
-    COUNT(DISTINCT transactions.remote_transaction_id) AS total_gifts,
-    COUNT(DISTINCT transactions.remote_person_id) AS total_donors, 
-    SUM(CASE WHEN transactions.is_recurring = '0' then transactions.amount end) AS one_time_revenue,
-    COUNT(CASE WHEN transactions.is_recurring = '0' then transactions.remote_transaction_id end) AS one_time_gifts,
-    SUM(CASE WHEN transactions.recurring_number = 1 then transactions.amount end) AS new_monthly_revenue,
-    COUNT(CASE WHEN transactions.recurring_number = 1 then transactions.remote_transaction_id end) AS new_monthly_gifts,
-    SUM(CASE WHEN transactions.is_recurring = '1' then transactions.amount end) AS total_monthly_revenue,
-    COUNT(CASE WHEN transactions.is_recurring = '1' then transactions.remote_transaction_id end) AS total_monthly_gifts
- FROM  {{ ref(email_summary) }} email_summary
- FULL OUTER JOIN {{ ref(transactions) }} transactions 
- ON CAST(email_summary.remote_id as STRING) = CAST(transactions.remote_message_id as STRING)
- GROUP BY 1 )
+with
+    grouped as (
+        select
+            email_summary.message_id as message_id,
+            sum(safe_cast(transactions.amount as numeric)) as total_revenue,
+            count(distinct transactions.remote_transaction_id) as total_gifts,
+            count(distinct transactions.remote_person_id) as total_donors,
+            sum(
+                case when transactions.is_recurring = '0' then transactions.amount end
+            ) as one_time_revenue,
+            count(
+                case
+                    when transactions.is_recurring = '0'
+                    then transactions.remote_transaction_id
+                end
+            ) as one_time_gifts,
+            sum(
+                case when transactions.recurring_number = 1 then transactions.amount end
+            ) as new_monthly_revenue,
+            count(
+                case
+                    when transactions.recurring_number = 1
+                    then transactions.remote_transaction_id
+                end
+            ) as new_monthly_gifts,
+            sum(
+                case when transactions.is_recurring = '1' then transactions.amount end
+            ) as total_monthly_revenue,
+            count(
+                case
+                    when transactions.is_recurring = '1'
+                    then transactions.remote_transaction_id
+                end
+            ) as total_monthly_gifts
+        from {{ ref(email_summary) }} email_summary
+        full outer join
+            {{ ref(transactions) }} transactions
+            on cast(email_summary.remote_id as string)
+            = cast(transactions.remote_message_id as string)
+        group by 1
+    )
 
-SELECT 
-    SAFE_CAST(message_id as STRING) AS message_id,
-    SAFE_CAST(total_revenue as NUMERIC) AS total_revenue,
-    SAFE_CAST(total_gifts as INT) AS total_gifts,
-    SAFE_CAST(total_donors as INT) AS total_donors,
-    SAFE_CAST(one_time_gifts as INT) AS one_time_gifts,
-    SAFE_CAST(one_time_revenue as NUMERIC) AS one_time_revenue,
-    SAFE_CAST(new_monthly_revenue  AS numeric) AS new_monthly_revenue,
-    SAFE_CAST(new_monthly_gifts  AS int) AS new_monthly_gifts,
-    SAFE_CAST(total_monthly_revenue AS numeric) AS total_monthly_revenue,
-    SAFE_CAST(total_monthly_gifts  AS int) AS total_monthly_gifts
-FROM GROUPED
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(total_revenue as numeric) as total_revenue,
+    safe_cast(total_gifts as int) as total_gifts,
+    safe_cast(total_donors as int) as total_donors,
+    safe_cast(one_time_gifts as int) as one_time_gifts,
+    safe_cast(one_time_revenue as numeric) as one_time_revenue,
+    safe_cast(new_monthly_revenue as numeric) as new_monthly_revenue,
+    safe_cast(new_monthly_gifts as int) as new_monthly_gifts,
+    safe_cast(total_monthly_revenue as numeric) as total_monthly_revenue,
+    safe_cast(total_monthly_gifts as int) as total_monthly_gifts
+from grouped
 
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_unsubscribes_rollup.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_email_unsubscribes_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_actionkit_email_unsubscribes_rollup(
-    reference_name='stg_frakture_actionkit_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(email_unsubscribes AS INT)) AS unsubscribes
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_actionkit_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(email_unsubscribes as int)) as unsubscribes
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_transactions_summary_unioned.sql
+++ b/macros/frakture_actionkit_email/staging/stg_frakture_actionkit_transactions_summary_unioned.sql
@@ -1,9 +1,11 @@
 {% macro create_stg_frakture_actionkit_transactions_summary_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^actionkit_[A-Za-z0-9]{3}_transaction$',
-  is_source=True,
-  source_name='frakture_actionkit_email',
-  schema_to_search='src_frakture') 
-%}
-SELECT DISTINCT * FROM ({{ dbt_utils.union_relations(relations) }})
-WHERE lower(order_status) = 'completed'
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^actionkit_[A-Za-z0-9]{3}_transaction$",
+    is_source=True,
+    source_name="frakture_actionkit_email",
+    schema_to_search="src_frakture",
+) %}
+select distinct *
+from ({{ dbt_utils.union_relations(relations) }})
+where lower(order_status) = 'completed'
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_actions_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_actions_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_everyaction_email_actions_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(actions AS INT)) AS actions
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(actions as int)) as actions
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_bounces_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_bounces_rollup.sql
@@ -1,10 +1,14 @@
 {% macro create_stg_frakture_everyaction_email_bounces_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_summary.email_hard_bounces + email_summary.email_soft_bounces AS INT) AS total_bounces,
-  SAFE_CAST(0 AS INT) AS block_bounces,
-  SAFE_CAST(0 AS INT) AS tech_bounces,
-  SAFE_CAST(email_summary.email_soft_bounces AS INT) AS soft_bounces,
-  SAFE_CAST(email_summary.email_hard_bounces AS INT) AS hard_bounces
-FROM  {{ ref(reference_name) }} email_summary
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(
+        email_summary.email_hard_bounces + email_summary.email_soft_bounces as int
+    ) as total_bounces,
+    safe_cast(0 as int) as block_bounces,
+    safe_cast(0 as int) as tech_bounces,
+    safe_cast(email_summary.email_soft_bounces as int) as soft_bounces,
+    safe_cast(email_summary.email_hard_bounces as int) as hard_bounces
+from {{ ref(reference_name) }} email_summary
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaign_dates.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaign_dates.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_everyaction_email_campaign_dates(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT 
-  SAFE_CAST(publish_date as TIMESTAMP) as campaign_timestamp,
-  SAFE_CAST(campaign_label AS STRING) AS crm_campaign,
-  SAFE_CAST(campaign AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(publish_date as timestamp) as campaign_timestamp,
+    safe_cast(campaign_label as string) as crm_campaign,
+    safe_cast(campaign as string) as source_code_campaign
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaign_dates_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaign_dates_rollup.sql
@@ -1,9 +1,10 @@
 {% macro create_stg_frakture_everyaction_email_campaign_dates_rollup(
-    reference_name='stg_frakture_everyaction_email_campaign_dates') %}
-SELECT 
-  COALESCE(crm_campaign,source_code_campaign) AS campaign_name,
-  MIN(campaign_timestamp) as campaign_start_timestamp,
-  MAX(campaign_timestamp) as campaign_latest_timestamp
-FROM {{ ref(reference_name) }}
-GROUP BY 1
+    reference_name="stg_frakture_everyaction_email_campaign_dates"
+) %}
+select
+    coalesce(crm_campaign, source_code_campaign) as campaign_name,
+    min(campaign_timestamp) as campaign_start_timestamp,
+    max(campaign_timestamp) as campaign_latest_timestamp
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaigns.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaigns.sql
@@ -1,14 +1,16 @@
 {% macro create_stg_frakture_everyaction_email_campaigns(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
 
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(bot_id as STRING) as crm_entity,
-  SAFE_CAST(account_prefix as STRING) as source_code_entity,
-  SAFE_CAST(audience as STRING) as audience,
-  SAFE_CAST(recurtype as STRING) as recurtype,
-  SAFE_CAST(message_set as STRING) as campaign_category,
-  SAFE_CAST(campaign_label AS STRING) AS crm_campaign,
-  SAFE_CAST(coalesce(campaign,campaign_label) AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(bot_id as string) as crm_entity,
+    safe_cast(account_prefix as string) as source_code_entity,
+    safe_cast(audience as string) as audience,
+    safe_cast(recurtype as string) as recurtype,
+    safe_cast(message_set as string) as campaign_category,
+    safe_cast(campaign_label as string) as crm_campaign,
+    safe_cast(coalesce(campaign, campaign_label) as string) as source_code_campaign
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaigns_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_campaigns_rollup.sql
@@ -1,11 +1,13 @@
 {% macro create_stg_frakture_everyaction_email_campaigns_rollup(
-    reference_name='stg_frakture_everyaction_email_campaigns') %}
-SELECT DISTINCT message_id,
+    reference_name="stg_frakture_everyaction_email_campaigns"
+) %}
+select distinct
+    message_id,
     crm_entity,
     source_code_entity,
     audience,
     recurtype,
     campaign_category,
-    COALESCE(crm_campaign,source_code_campaign) AS campaign_name
-FROM {{ ref(reference_name) }}
+    coalesce(crm_campaign, source_code_campaign) as campaign_name
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_clicks_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_clicks_rollup.sql
@@ -1,6 +1,8 @@
 {% macro create_stg_frakture_everyaction_email_clicks_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_summary.email_clicked AS INT) AS clicks
-FROM  {{ ref(reference_name) }} email_summary
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_summary.email_clicked as int) as clicks
+from {{ ref(reference_name) }} email_summary
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_complaints_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_complaints_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_everyaction_email_complaints_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
-  SUM(SAFE_CAST(email_spam_complaints AS INT)) AS complaints
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(email_spam_complaints as int)) as complaints
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_jobs.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_jobs.sql
@@ -1,17 +1,20 @@
 {% macro create_stg_frakture_everyaction_email_jobs(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
 
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) as message_id, 
-    SAFE_CAST(from_name AS STRING) as from_name,
-    SAFE_CAST(from_email AS STRING) as from_email,
-    SAFE_CAST({{ dbt_date.convert_timezone('cast(publish_date as TIMESTAMP)') }} as TIMESTAMP) as best_guess_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) as scheduled_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) as pickup_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) as delivered_timestamp,
-    SAFE_CAST(label AS STRING) as email_name,
-    SAFE_CAST(subject AS STRING) as email_subject,
-    SAFE_CAST(final_primary_source_code AS STRING) as source_code
-FROM {{ ref(reference_name) }}
-
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(from_name as string) as from_name,
+    safe_cast(from_email as string) as from_email,
+    safe_cast(
+        {{ dbt_date.convert_timezone("cast(publish_date as TIMESTAMP)") }} as timestamp
+    ) as best_guess_timestamp,
+    safe_cast(null as timestamp) as scheduled_timestamp,
+    safe_cast(null as timestamp) as pickup_timestamp,
+    safe_cast(null as timestamp) as delivered_timestamp,
+    safe_cast(label as string) as email_name,
+    safe_cast(subject as string) as email_subject,
+    safe_cast(final_primary_source_code as string) as source_code
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_opens_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_opens_rollup.sql
@@ -1,6 +1,8 @@
 {% macro create_stg_frakture_everyaction_email_opens_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_summary.email_opened AS INT) AS opens
-FROM  {{ ref(reference_name) }} email_summary
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_summary.email_opened as int) as opens
+from {{ ref(reference_name) }} email_summary
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_recipients_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_recipients_rollup.sql
@@ -1,6 +1,8 @@
 {% macro create_stg_frakture_everyaction_email_recipients_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_summary.email_sent AS INT) AS recipients
-FROM  {{ ref(reference_name) }} email_summary
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_summary.email_sent as int) as recipients
+from {{ ref(reference_name) }} email_summary
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_summary_unioned.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_summary_unioned.sql
@@ -1,9 +1,11 @@
 {% macro create_stg_frakture_everyaction_email_summary_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^everyaction_[A-Za-z0-9]{3}_email_summary$',
-  is_source=True,
-  source_name='frakture_everyaction_email',
-  schema_to_search='src_frakture') 
-%}
-SELECT DISTINCT * FROM ({{ dbt_utils.union_relations(relations) }})
-WHERE message_id IS NOT NULL
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^everyaction_[A-Za-z0-9]{3}_email_summary$",
+    is_source=True,
+    source_name="frakture_everyaction_email",
+    schema_to_search="src_frakture",
+) %}
+select distinct *
+from ({{ dbt_utils.union_relations(relations) }})
+where message_id is not null
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_unsubscribes_rollup.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_email_unsubscribes_rollup.sql
@@ -1,6 +1,8 @@
 {% macro create_stg_frakture_everyaction_email_unsubscribes_rollup(
-    reference_name='stg_frakture_everyaction_email_summary_unioned') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_summary.email_unsubscribes AS INT) AS unsubscribes
-FROM  {{ ref(reference_name) }} email_summary
+    reference_name="stg_frakture_everyaction_email_summary_unioned"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_summary.email_unsubscribes as int) as unsubscribes
+from {{ ref(reference_name) }} email_summary
 {% endmacro %}

--- a/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_transactions_summary_unioned.sql
+++ b/macros/frakture_everyaction_email/staging/stg_frakture_everyaction_transactions_summary_unioned.sql
@@ -1,8 +1,10 @@
 {% macro create_stg_frakture_everyaction_transactions_summary_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^everyaction_[A-Za-z0-9]{3}_transaction$',
-  is_source=True,
-  source_name='frakture_everyaction_email',
-  schema_to_search='src_frakture') 
-%}
-SELECT DISTINCT * FROM ({{ dbt_utils.union_relations(relations) }})
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^everyaction_[A-Za-z0-9]{3}_transaction$",
+    is_source=True,
+    source_name="frakture_everyaction_email",
+    schema_to_search="src_frakture",
+) %}
+select distinct *
+from ({{ dbt_utils.union_relations(relations) }})
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_actions_daily_rollup.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_actions_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_everyaction_person_actions_daily_rollup(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(action AS INT)) as actions
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(action as int)) as actions
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_bounces_daily_rollup.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_bounces_daily_rollup.sql
@@ -1,11 +1,12 @@
 {% macro create_stg_frakture_everyaction_person_bounces_daily_rollup(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(hard_bounce AS INT)) as hard_bounces,
-  SUM(SAFE_CAST(soft_bounce AS INT)) as soft_bounces
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(hard_bounce as int)) as hard_bounces,
+    sum(safe_cast(soft_bounce as int)) as soft_bounces
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_clicks_daily_rollup.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_clicks_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_everyaction_person_clicks_daily_rollup(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(clicked AS INT)) as clicks
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(clicked as int)) as clicks
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_jobs.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_jobs.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_everyaction_person_jobs(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-  SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(email_domain as STRING) as email_domain
-FROM  {{ ref(reference_name) }} 
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(email_domain as string) as email_domain
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_jobs_distinct.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_jobs_distinct.sql
@@ -1,4 +1,5 @@
 {% macro create_stg_frakture_everyaction_person_jobs_distinct(
-    reference_name='stg_frakture_everyaction_person_jobs') %}
-  SELECT DISTINCT * FROM  {{ ref(reference_name) }} 
+    reference_name="stg_frakture_everyaction_person_jobs"
+) %}
+select distinct * from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_message_stat_unioned.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_message_stat_unioned.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_everyaction_person_message_stat_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^everyaction_[A-Za-z0-9]{3}_per_person_message_stat$',
-  is_source=True,
-  source_name='frakture_everyaction_person',
-  schema_to_search='src_frakture') 
-%}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^everyaction_[A-Za-z0-9]{3}_per_person_message_stat$",
+    is_source=True,
+    source_name="frakture_everyaction_person",
+    schema_to_search="src_frakture",
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_message_stat_unioned_with_domain.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_message_stat_unioned_with_domain.sql
@@ -1,10 +1,9 @@
 {% macro create_stg_frakture_everyaction_person_message_stat_unioned_with_domain(
-  person_stat='stg_frakture_everyaction_person_message_stat_unioned',
-  person='stg_frakture_everyaction_person_table_unioned') %}
-SELECT
-person_stat.*,
-person.email_domain
-FROM  {{ ref(person_stat) }} person_stat 
-LEFT JOIN {{ ref(person) }} person
-ON person_stat.remote_person_id = person.remote_person_id
+    person_stat="stg_frakture_everyaction_person_message_stat_unioned",
+    person="stg_frakture_everyaction_person_table_unioned"
+) %}
+select person_stat.*, person.email_domain
+from {{ ref(person_stat) }} person_stat
+left join
+    {{ ref(person) }} person on person_stat.remote_person_id = person.remote_person_id
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_opens_daily_rollup.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_opens_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_everyaction_person_opens_daily_rollup(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(opened AS INT)) as opens
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(opened as int)) as opens
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_recipients_daily_rollup.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_recipients_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_everyaction_person_recipients_daily_rollup(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(received AS INT)) as recipients
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(received as int)) as recipients
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_table_unioned.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_table_unioned.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_everyaction_person_table_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^everyaction_[A-Za-z0-9]{3}_person$',
-  is_source=True,
-  source_name='frakture_everyaction_person',
-  schema_to_search='src_frakture') 
-%}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^everyaction_[A-Za-z0-9]{3}_person$",
+    is_source=True,
+    source_name="frakture_everyaction_person",
+    schema_to_search="src_frakture",
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_unsubscribes_daily_rollup.sql
+++ b/macros/frakture_everyaction_person/staging/stg_frakture_everyaction_person_unsubscribes_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_everyaction_person_unsubscribes_daily_rollup(
-    reference_name='stg_frakture_everyaction_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(unsubscribe AS INT)) as unsubscribes
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_everyaction_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(unsubscribe as int)) as unsubscribes
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_actions_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_actions_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_actions_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
-  SUM(SAFE_CAST(actions AS INT)) AS actions
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(actions as int)) as actions
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_bounces_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_bounces_rollup.sql
@@ -1,11 +1,13 @@
 {% macro create_stg_frakture_global_message_email_bounces_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
- SUM(SAFE_CAST(hard_bounces + soft_bounces AS INT)) AS total_bounces,
-  SUM(SAFE_CAST(0 AS INT)) AS block_bounces,
-  SUM(SAFE_CAST(0 AS INT)) AS tech_bounces,
-  SUM(SAFE_CAST(soft_bounces AS INT)) AS soft_bounces,
-  SUM(SAFE_CAST(hard_bounces AS INT)) AS hard_bounces
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(hard_bounces + soft_bounces as int)) as total_bounces,
+    sum(safe_cast(0 as int)) as block_bounces,
+    sum(safe_cast(0 as int)) as tech_bounces,
+    sum(safe_cast(soft_bounces as int)) as soft_bounces,
+    sum(safe_cast(hard_bounces as int)) as hard_bounces
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaign_dates.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaign_dates.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_global_message_email_campaign_dates(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT 
-  SAFE_CAST(publish_date as TIMESTAMP) as campaign_timestamp,
-  SAFE_CAST(campaign_name AS STRING) AS crm_campaign,
-  SAFE_CAST(coalesce(campaign,campaign_label) AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(publish_date as timestamp) as campaign_timestamp,
+    safe_cast(campaign_name as string) as crm_campaign,
+    safe_cast(coalesce(campaign, campaign_label) as string) as source_code_campaign
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaign_dates_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaign_dates_rollup.sql
@@ -1,9 +1,10 @@
 {% macro create_stg_frakture_global_message_email_campaign_dates_rollup(
-    reference_name='stg_frakture_global_message_email_campaign_dates') %}
-SELECT 
-  COALESCE(crm_campaign,source_code_campaign) AS campaign_name,
-  MIN(campaign_timestamp) as campaign_start_timestamp,
-  MAX(campaign_timestamp) as campaign_latest_timestamp
-FROM {{ ref(reference_name) }}
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_campaign_dates"
+) %}
+select
+    coalesce(crm_campaign, source_code_campaign) as campaign_name,
+    min(campaign_timestamp) as campaign_start_timestamp,
+    max(campaign_timestamp) as campaign_latest_timestamp
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaigns.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaigns.sql
@@ -1,13 +1,15 @@
 {% macro create_stg_frakture_global_message_email_campaigns(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(bot_nickname as STRING) as crm_entity,
-  SAFE_CAST(account_prefix as STRING) as source_code_entity,
-  SAFE_CAST(audience as STRING) as audience,
-  SAFE_CAST(recurtype as STRING) as recurtype,
-  SAFE_CAST(message_set as STRING) as campaign_category,
-  SAFE_CAST(campaign_name AS STRING) AS crm_campaign,
-  SAFE_CAST(coalesce(campaign,campaign_label) AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(bot_nickname as string) as crm_entity,
+    safe_cast(account_prefix as string) as source_code_entity,
+    safe_cast(audience as string) as audience,
+    safe_cast(recurtype as string) as recurtype,
+    safe_cast(message_set as string) as campaign_category,
+    safe_cast(campaign_name as string) as crm_campaign,
+    safe_cast(coalesce(campaign, campaign_label) as string) as source_code_campaign
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaigns_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_campaigns_rollup.sql
@@ -1,11 +1,13 @@
 {% macro create_stg_frakture_global_message_email_campaigns_rollup(
-    reference_name='stg_frakture_global_message_email_campaigns') %}
-SELECT DISTINCT message_id,
+    reference_name="stg_frakture_global_message_email_campaigns"
+) %}
+select distinct
+    message_id,
     crm_entity,
     source_code_entity,
     audience,
     recurtype,
     campaign_category,
-    COALESCE(crm_campaign,source_code_campaign) AS campaign_name
-FROM {{ ref(reference_name) }}
+    coalesce(crm_campaign, source_code_campaign) as campaign_name
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_clicks_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_clicks_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_clicks_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
-  SUM(SAFE_CAST(clicks AS INT)) AS clicks
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(clicks as int)) as clicks
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_complaints_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_complaints_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_complaints_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,  
-  SUM(SAFE_CAST(complaints AS INT)) AS complaints
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(complaints as int)) as complaints
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_jobs.sql
@@ -1,15 +1,18 @@
 {% macro create_stg_frakture_global_message_email_jobs(
-    reference_name='stg_frakture_global_message_email_message') %}
-SELECT 
-   DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-    SAFE_CAST(REGEXP_EXTRACT(from_name, "\".*?\"") AS STRING) AS from_name,
-    SAFE_CAST(REGEXP_EXTRACT(from_name, "<.*?>") AS STRING) AS from_email,
-    SAFE_CAST({{ dbt_date.convert_timezone('cast(publish_date as TIMESTAMP)') }} as TIMESTAMP) as best_guess_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) AS scheduled_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) AS pickup_timestamp,
-    SAFE_CAST(NULL AS TIMESTAMP) AS delivered_timestamp,
-    SAFE_CAST(label AS STRING) AS email_name,
-    SAFE_CAST(subject AS STRING) AS email_subject,
-    SAFE_CAST(final_primary_source_code as STRING) as source_code
-FROM {{ ref(reference_name) }}
+    reference_name="stg_frakture_global_message_email_message"
+) %}
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(regexp_extract(from_name, "\".*?\"") as string) as from_name,
+    safe_cast(regexp_extract(from_name, "<.*?>") as string) as from_email,
+    safe_cast(
+        {{ dbt_date.convert_timezone("cast(publish_date as TIMESTAMP)") }} as timestamp
+    ) as best_guess_timestamp,
+    safe_cast(null as timestamp) as scheduled_timestamp,
+    safe_cast(null as timestamp) as pickup_timestamp,
+    safe_cast(null as timestamp) as delivered_timestamp,
+    safe_cast(label as string) as email_name,
+    safe_cast(subject as string) as email_subject,
+    safe_cast(final_primary_source_code as string) as source_code
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_message.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_message.sql
@@ -1,5 +1,5 @@
 {% macro create_stg_frakture_global_message_email_message() %}
-SELECT DISTINCT * FROM {{ source('frakture_global_message_email','global_message') }}
- WHERE message_id IS NOT NULL
- AND channel = 'email'
+select distinct *
+from {{ source("frakture_global_message_email", "global_message") }}
+where message_id is not null and channel = 'email'
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_opens_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_opens_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_opens_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(impressions AS INT)) AS opens
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(impressions as int)) as opens
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_recipients_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_recipients_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_recipients_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SUM(SAFE_CAST(sent AS INT)) AS recipients
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(sent as int)) as recipients
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_summary.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_summary.sql
@@ -1,5 +1,5 @@
 {% macro create_stg_frakture_global_message_email_summary() %}
-SELECT DISTINCT * FROM {{ source('frakture_global_message_email','global_message_summary_by_date') }}
- WHERE message_id IS NOT NULL
- AND channel = 'email'
+select distinct *
+from {{ source("frakture_global_message_email", "global_message_summary_by_date") }}
+where message_id is not null and channel = 'email'
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_transactions_sourced_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_transactions_sourced_rollup.sql
@@ -1,15 +1,25 @@
 {% macro create_stg_frakture_global_message_email_transactions_sourced_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,   
-    SUM(SAFE_CAST(attributed_revenue AS numeric)) AS total_revenue,
-    SUM(SAFE_CAST(attributed_transactions AS int)) AS total_gifts,
-    SUM(SAFE_CAST(origin_person_count AS int)) AS total_donors,  -- doesn't seem available in Frakture ad_summary tables
-    SUM(SAFE_CAST(attributed_revenue - attributed_recurring_revenue AS numeric)) AS one_time_revenue,
-    SUM(SAFE_CAST(attributed_transactions - attributed_recurring_transactions  AS int)) AS one_time_gifts,
-    SUM(SAFE_CAST(attributed_initial_recurring_revenue  AS numeric)) AS new_monthly_revenue,
-    SUM(SAFE_CAST(attributed_initial_recurring_transactions  AS int)) AS new_monthly_gifts, 
-    SUM(SAFE_CAST(attributed_recurring_revenue  AS numeric)) AS total_monthly_revenue,
-    SUM(SAFE_CAST(attributed_recurring_transactions  AS int)) AS total_monthly_gifts
- FROM  {{ ref(reference_name) }} 
- GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(attributed_revenue as numeric)) as total_revenue,
+    sum(safe_cast(attributed_transactions as int)) as total_gifts,
+    sum(safe_cast(origin_person_count as int)) as total_donors,  -- doesn't seem available in Frakture ad_summary tables
+    sum(
+        safe_cast(attributed_revenue - attributed_recurring_revenue as numeric)
+    ) as one_time_revenue,
+    sum(
+        safe_cast(attributed_transactions - attributed_recurring_transactions as int)
+    ) as one_time_gifts,
+    sum(
+        safe_cast(attributed_initial_recurring_revenue as numeric)
+    ) as new_monthly_revenue,
+    sum(
+        safe_cast(attributed_initial_recurring_transactions as int)
+    ) as new_monthly_gifts,
+    sum(safe_cast(attributed_recurring_revenue as numeric)) as total_monthly_revenue,
+    sum(safe_cast(attributed_recurring_transactions as int)) as total_monthly_gifts
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_unsubscribes_rollup.sql
+++ b/macros/frakture_global_message_email/staging/stg_frakture_global_message_email_unsubscribes_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_email_unsubscribes_rollup(
-    reference_name='stg_frakture_global_message_email_summary') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
- SUM(SAFE_CAST(unsubscribes AS INT)) AS unsubscribes
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_frakture_global_message_email_summary"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    sum(safe_cast(unsubscribes as int)) as unsubscribes
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_ad_summary_by_date.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_ad_summary_by_date.sql
@@ -1,5 +1,5 @@
 {% macro create_stg_frakture_global_message_paidmedia_ad_summary_by_date() %}
-SELECT DISTINCT * FROM {{ source('frakture_global_message_paidmedia','global_message_summary_by_date') }}
- WHERE message_id IS NOT NULL
- AND channel != 'email'
+select distinct *
+from {{ source("frakture_global_message_paidmedia", "global_message_summary_by_date") }}
+where message_id is not null and channel != 'email'
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_campaigns.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_campaigns.sql
@@ -1,20 +1,29 @@
 {% macro create_stg_frakture_global_message_paidmedia_campaigns(
-    reference_name='stg_frakture_global_message_paidmedia_message') %}
-SELECT DISTINCT SAFE_CAST(campaign_id AS STRING) AS campaign_id,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-    CASE WHEN REGEXP_CONTAINS(type,'(?i)search')=True THEN 'search'
-    WHEN REGEXP_CONTAINS(type,'(?i)ad')=True THEN 'search'
-    WHEN REGEXP_CONTAINS(type,'(?i)display')=True THEN 'display'
-    WHEN REGEXP_CONTAINS(type,'(?i)video')=True THEN 'display'
-    WHEN channel IN ('ad') THEN 'search'
-    WHEN channel IN ('facebook_ad', 'promoted_tweet') THEN 'social'
-    ELSE CONCAT(channel, ' - ', type) 
-  END AS channel_category,
-  SAFE_CAST(channel AS STRING) AS channel,
-  SAFE_CAST(type AS STRING) AS channel_type,
-  SAFE_CAST(campaign_name AS STRING) AS campaign_name,
-  SAFE_CAST(bot_id as STRING) as crm_entity,
-  SAFE_CAST(account_prefix as STRING) as source_code_entity,
-  SAFE_CAST(preview_url as STRING) as preview_url
-FROM {{ ref(reference_name) }}
+    reference_name="stg_frakture_global_message_paidmedia_message"
+) %}
+select distinct
+    safe_cast(campaign_id as string) as campaign_id,
+    safe_cast(message_id as string) as message_id,
+    case
+        when regexp_contains(type, '(?i)search') = true
+        then 'search'
+        when regexp_contains(type, '(?i)ad') = true
+        then 'search'
+        when regexp_contains(type, '(?i)display') = true
+        then 'display'
+        when regexp_contains(type, '(?i)video') = true
+        then 'display'
+        when channel in ('ad')
+        then 'search'
+        when channel in ('facebook_ad', 'promoted_tweet')
+        then 'social'
+        else concat(channel, ' - ', type)
+    end as channel_category,
+    safe_cast(channel as string) as channel,
+    safe_cast(type as string) as channel_type,
+    safe_cast(campaign_name as string) as campaign_name,
+    safe_cast(bot_id as string) as crm_entity,
+    safe_cast(account_prefix as string) as source_code_entity,
+    safe_cast(preview_url as string) as preview_url
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_clicks_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_clicks_daily_rollup.sql
@@ -1,8 +1,10 @@
 {% macro create_stg_frakture_global_message_paidmedia_clicks_daily_rollup(
-    reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,  
-SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(ad_summary_by_date.clicks AS INT) AS total_clicks,
-  SAFE_CAST(ad_summary_by_date.clicks AS INT) AS unique_clicks
-FROM {{ ref(reference_name) }} ad_summary_by_date
+    reference_name="stg_frakture_global_message_paidmedia_ad_summary_by_date"
+) %}
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary_by_date.clicks as int) as total_clicks,
+    safe_cast(ad_summary_by_date.clicks as int) as unique_clicks
+from {{ ref(reference_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_impressions_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_impressions_daily_rollup.sql
@@ -1,7 +1,10 @@
 {% macro create_stg_frakture_global_message_paidmedia_impressions_daily_rollup(
-    reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(ad_summary_by_date.impressions AS INT) AS total_impressions,
-  SAFE_CAST(NULL AS INT) AS unique_impressions
-FROM {{ ref(reference_name) }} ad_summary_by_date
+    reference_name="stg_frakture_global_message_paidmedia_ad_summary_by_date"
+) %}
+select distinct
+    safe_cast(ad_summary_by_date.message_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary_by_date.impressions as int) as total_impressions,
+    safe_cast(null as int) as unique_impressions
+from {{ ref(reference_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_message.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_message.sql
@@ -1,5 +1,5 @@
 {% macro create_stg_frakture_global_message_paidmedia_message() %}
-SELECT DISTINCT * FROM {{ source('frakture_global_message_paidmedia','global_message') }}
- WHERE message_id IS NOT NULL
- AND channel != 'email'
+select distinct *
+from {{ source("frakture_global_message_paidmedia", "global_message") }}
+where message_id is not null and channel != 'email'
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_sources_campaigns_messages_bridge.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_sources_campaigns_messages_bridge.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_paidmedia_sources_campaigns_messages_bridge(
-    reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT SAFE_CAST(message_id AS STRING) AS message_id,
-       SAFE_CAST(primary_source_code AS STRING) AS source_code,       
-       SAFE_CAST(campaign_id AS STRING) AS campaign_id
-FROM  {{ ref(reference_name) }}
+    reference_name="stg_frakture_global_message_paidmedia_ad_summary_by_date"
+) %}
+select distinct
+    safe_cast(message_id as string) as message_id,
+    safe_cast(primary_source_code as string) as source_code,
+    safe_cast(campaign_id as string) as campaign_id
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_spends_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_spends_daily_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_paidmedia_spends_daily_rollup(
-    reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT  SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,
-  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(ad_summary_by_date.spend AS NUMERIC) AS spend_amount
-FROM  {{ ref(reference_name) }} ad_summary_by_date
+    reference_name="stg_frakture_global_message_paidmedia_ad_summary_by_date"
+) %}
+select distinct
+    safe_cast(ad_summary_by_date.message_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary_by_date.spend as numeric) as spend_amount
+from {{ ref(reference_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_subscribes_daily_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_subscribes_daily_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_global_message_paidmedia_subscribes_daily_rollup(
-    reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT DISTINCT  SAFE_CAST(ad_summary_by_date.message_id AS STRING) AS message_id,
-  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(NULL AS INTEGER) AS subscribes
-FROM  {{ ref(reference_name) }} ad_summary_by_date
+    reference_name="stg_frakture_global_message_paidmedia_ad_summary_by_date"
+) %}
+select distinct
+    safe_cast(ad_summary_by_date.message_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(null as integer) as subscribes
+from {{ ref(reference_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_transactions_sourced_rollup.sql
+++ b/macros/frakture_global_message_paidmedia/staging/stg_frakture_global_message_paidmedia_transactions_sourced_rollup.sql
@@ -1,21 +1,37 @@
 {% macro create_stg_frakture_global_message_paidmedia_transactions_sourced_rollup(
-    reference_name='stg_frakture_global_message_paidmedia_ad_summary_by_date') %}
-SELECT SAFE_CAST(ad_summary.message_id AS STRING) AS message_id,
-    SAFE_CAST(ad_summary.date AS TIMESTAMP) AS date_timestamp,
-    SAFE_CAST(ad_summary.attributed_revenue AS numeric) AS total_revenue,
-    SAFE_CAST(ad_summary.attributed_transactions AS int) AS total_gifts,
-    SAFE_CAST(ad_summary.origin_person_count AS int) AS total_donors, 
-    SAFE_CAST(ad_summary.attributed_revenue - ad_summary.attributed_recurring_revenue AS numeric) AS one_time_revenue,
-    SAFE_CAST(ad_summary.attributed_transactions - ad_summary.attributed_recurring_transactions  AS int) AS one_time_gifts,
-    SAFE_CAST(ad_summary.attributed_initial_recurring_revenue  AS numeric) AS new_monthly_revenue,
-    SAFE_CAST(ad_summary.attributed_initial_recurring_transactions  AS int) AS new_monthly_gifts,
-    SAFE_CAST(ad_summary.attributed_recurring_revenue  AS numeric) AS total_monthly_revenue,
-    SAFE_CAST(ad_summary.attributed_recurring_transactions  AS int) AS total_monthly_gifts,
-    SAFE_CAST(ad_summary.goal AS STRING) AS objective,
-    SAFE_CAST(ad_summary.campaign  AS STRING) AS campaign,
-    SAFE_CAST(ad_summary.campaign_label  AS STRING) AS campaign_label,
-    SAFE_CAST(ad_summary.audience  AS STRING) AS audience,
-    SAFE_CAST(ad_summary.appeal AS STRING) AS appeal,
-    SAFE_CAST(ad_summary.final_primary_source_code as STRING) as source_code
- FROM  {{ ref(reference_name) }} ad_summary
+    reference_name="stg_frakture_global_message_paidmedia_ad_summary_by_date"
+) %}
+select
+    safe_cast(ad_summary.message_id as string) as message_id,
+    safe_cast(ad_summary.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary.attributed_revenue as numeric) as total_revenue,
+    safe_cast(ad_summary.attributed_transactions as int) as total_gifts,
+    safe_cast(ad_summary.origin_person_count as int) as total_donors,
+    safe_cast(
+        ad_summary.attributed_revenue
+        - ad_summary.attributed_recurring_revenue as numeric
+    ) as one_time_revenue,
+    safe_cast(
+        ad_summary.attributed_transactions
+        - ad_summary.attributed_recurring_transactions as int
+    ) as one_time_gifts,
+    safe_cast(
+        ad_summary.attributed_initial_recurring_revenue as numeric
+    ) as new_monthly_revenue,
+    safe_cast(
+        ad_summary.attributed_initial_recurring_transactions as int
+    ) as new_monthly_gifts,
+    safe_cast(
+        ad_summary.attributed_recurring_revenue as numeric
+    ) as total_monthly_revenue,
+    safe_cast(
+        ad_summary.attributed_recurring_transactions as int
+    ) as total_monthly_gifts,
+    safe_cast(ad_summary.goal as string) as objective,
+    safe_cast(ad_summary.campaign as string) as campaign,
+    safe_cast(ad_summary.campaign_label as string) as campaign_label,
+    safe_cast(ad_summary.audience as string) as audience,
+    safe_cast(ad_summary.appeal as string) as appeal,
+    safe_cast(ad_summary.final_primary_source_code as string) as source_code
+from {{ ref(reference_name) }} ad_summary
 {% endmacro %}

--- a/macros/frakture_global_transactions/staging/stg_frakture_global_transactions.sql
+++ b/macros/frakture_global_transactions/staging/stg_frakture_global_transactions.sql
@@ -1,23 +1,24 @@
 {% macro create_stg_frakture_global_transactions(
-    source_name='frakture_global_transactions',
-    source_table_name='transaction_summary') %}
-SELECT
-  REGEXP_EXTRACT(transaction_bot_id,'([A-Za-z_]+)_[a-z0-9]{3}') AS source_crm,
-  remote_transaction_id AS transaction_id_in_source_crm,
-  person_id_int AS person_id,
-  amount - refund_amount AS amount,
-  SAFE_CAST({{ dbt_date.convert_timezone('cast(ts as TIMESTAMP)') }} as TIMESTAMP) as transaction_timestamp,
-  recurs != 'Non-recurring' AS recurring_revenue,
-  recurs_int = 1
-  AND recurs != 'Non-recurring' AS new_recurring_revenue,
-  transaction_source_code,
-  message_id AS best_guess_message_id,
-  campaign AS campaign,
-  channel AS channel,
-  audience AS audience,
-  safe_cast(transaction_bot_id as STRING) as crm_entity,
-  safe_cast(affiliation as STRING) as source_code_entity,
-  source_code_channel AS channel_from_source_code
-FROM
-  {{ source(source_name,source_table_name) }}
+    source_name="frakture_global_transactions",
+    source_table_name="transaction_summary"
+) %}
+select
+    regexp_extract(transaction_bot_id, '([A-Za-z_]+)_[a-z0-9]{3}') as source_crm,
+    remote_transaction_id as transaction_id_in_source_crm,
+    person_id_int as person_id,
+    amount - refund_amount as amount,
+    safe_cast(
+        {{ dbt_date.convert_timezone("cast(ts as TIMESTAMP)") }} as timestamp
+    ) as transaction_timestamp,
+    recurs != 'Non-recurring' as recurring_revenue,
+    recurs_int = 1 and recurs != 'Non-recurring' as new_recurring_revenue,
+    transaction_source_code,
+    message_id as best_guess_message_id,
+    campaign as campaign,
+    channel as channel,
+    audience as audience,
+    safe_cast(transaction_bot_id as string) as crm_entity,
+    safe_cast(affiliation as string) as source_code_entity,
+    source_code_channel as channel_from_source_code
+from {{ source(source_name, source_table_name) }}
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_actions_daily_rollup.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_actions_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_sfmc_person_actions_daily_rollup(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(0 AS INT)) as actions
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(0 as int)) as actions
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_bounces_daily_rollup.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_bounces_daily_rollup.sql
@@ -1,11 +1,12 @@
 {% macro create_stg_frakture_sfmc_person_bounces_daily_rollup(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(bounced AS INT)) as hard_bounces,
-  SUM(SAFE_CAST(0 AS INT)) as soft_bounces
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(bounced as int)) as hard_bounces,
+    sum(safe_cast(0 as int)) as soft_bounces
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_clicks_daily_rollup.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_clicks_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_sfmc_person_clicks_daily_rollup(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(clicked AS INT)) as clicks
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(clicked as int)) as clicks
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_jobs.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_jobs.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_frakture_sfmc_person_jobs(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-  SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(email_domain as STRING) as email_domain
-FROM  {{ ref(reference_name) }} 
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(email_domain as string) as email_domain
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_jobs_distinct.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_jobs_distinct.sql
@@ -1,4 +1,5 @@
 {% macro create_stg_frakture_sfmc_person_jobs_distinct(
-    reference_name='stg_frakture_sfmc_person_jobs') %}
-  SELECT DISTINCT * FROM  {{ ref(reference_name) }} 
+    reference_name="stg_frakture_sfmc_person_jobs"
+) %}
+select distinct * from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_message_stat_unioned.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_message_stat_unioned.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_sfmc_person_message_stat_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^sfmc_[A-Za-z0-9]{3}_per_person_message_stat$',
-  is_source=True,
-  source_name='frakture_sfmc_person',
-  schema_to_search='src_frakture') 
-%}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^sfmc_[A-Za-z0-9]{3}_per_person_message_stat$",
+    is_source=True,
+    source_name="frakture_sfmc_person",
+    schema_to_search="src_frakture",
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_message_stat_unioned_with_domain.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_message_stat_unioned_with_domain.sql
@@ -1,10 +1,9 @@
 {% macro create_stg_frakture_sfmc_person_message_stat_unioned_with_domain(
-  person_stat='stg_frakture_sfmc_person_message_stat_unioned',
-  person='stg_frakture_sfmc_person_table_unioned') %}
-SELECT
-person_stat.*,
-person.email_domain
-FROM  {{ ref(person_stat) }} person_stat 
-LEFT JOIN {{ ref(person) }} person
-ON person_stat.remote_person_id = person.remote_person_id
+    person_stat="stg_frakture_sfmc_person_message_stat_unioned",
+    person="stg_frakture_sfmc_person_table_unioned"
+) %}
+select person_stat.*, person.email_domain
+from {{ ref(person_stat) }} person_stat
+left join
+    {{ ref(person) }} person on person_stat.remote_person_id = person.remote_person_id
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_opens_daily_rollup.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_opens_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_sfmc_person_opens_daily_rollup(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(opened AS INT)) as opens
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(opened as int)) as opens
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_recipients_daily_rollup.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_recipients_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_sfmc_person_recipients_daily_rollup(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(0 AS INT)) as recipients
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(0 as int)) as recipients
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_table_unioned.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_table_unioned.sql
@@ -1,8 +1,9 @@
 {% macro create_stg_frakture_sfmc_person_table_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^sfmc_[A-Za-z0-9]{3}_person$',
-  is_source=True,
-  source_name='frakture_sfmc_person',
-  schema_to_search='src_frakture') 
-%}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^sfmc_[A-Za-z0-9]{3}_person$",
+    is_source=True,
+    source_name="frakture_sfmc_person",
+    schema_to_search="src_frakture",
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_unsubscribes_daily_rollup.sql
+++ b/macros/frakture_sfmc_person/staging/stg_frakture_sfmc_person_unsubscribes_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_frakture_sfmc_person_unsubscribes_daily_rollup(
-    reference_name='stg_frakture_sfmc_person_message_stat_unioned_with_domain') %}
-SELECT 
-  SAFE_CAST(sent_ts as DATE) AS sent_date,
-  SAFE_CAST(message_id AS STRING) AS message_id,
-  SAFE_CAST(email_domain as STRING) as email_domain,
-  SUM(SAFE_CAST(unsubscribed AS INT)) as unsubscribes
-FROM  {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3
+    reference_name="stg_frakture_sfmc_person_message_stat_unioned_with_domain"
+) %}
+select
+    safe_cast(sent_ts as date) as sent_date,
+    safe_cast(message_id as string) as message_id,
+    safe_cast(email_domain as string) as email_domain,
+    sum(safe_cast(unsubscribed as int)) as unsubscribes
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 {% endmacro %}

--- a/macros/paidmedia/marts/mart_paidmedia_daily_revenue_performance.sql
+++ b/macros/paidmedia/marts/mart_paidmedia_daily_revenue_performance.sql
@@ -1,63 +1,74 @@
 {% macro create_mart_paidmedia_daily_revenue_performance(
-    campaigns='stg_paidmedia_campaigns_unioned',
-    impressions='stg_paidmedia_impressions_daily_rollup_unioned',
-    clicks='stg_paidmedia_clicks_daily_rollup_unioned',
-    spends='stg_paidmedia_spends_daily_rollup_unioned',
-    transactions='stg_paidmedia_transactions_sourced_daily_rollup_unioned',
-    subscribes='stg_paidmedia_subscribes_daily_rollup_unioned') %}
-SELECT
-      COALESCE(campaigns.message_id, 
-               impressions.message_id) AS message_id,
-      campaigns.campaign_id,
-      COALESCE(campaigns.channel,
-               REGEXP_EXTRACT(impressions._dbt_source_relation, 
-                              'stg_[a-z]+_([a-z_]+)_paidmedia')) 
-                                       AS channel,
-      campaigns.channel_category,
-      campaigns.channel_type,
-      campaigns.campaign_name,
-      campaigns.crm_entity,
-      campaigns.source_code_entity,
-      case when (campaigns.crm_entity is not null and campaigns.source_code_entity is not null)
-          then CONCAT(campaigns.crm_entity,'-', campaigns.source_code_entity)
-          else COALESCE(campaigns.crm_entity,campaigns.source_code_entity) END
-          as best_guess_entity,
-      campaigns.preview_url,
-      impressions.date_timestamp,
-      impressions.total_impressions,
-      impressions.unique_impressions,
-      clicks.total_clicks,
-      clicks.unique_clicks,
-      spend.spend_amount,
-      transactions.total_revenue,
-      transactions.total_gifts,
-      transactions.total_donors,
-      transactions.one_time_revenue,
-      transactions.one_time_gifts,
-      transactions.new_monthly_revenue,
-      transactions.new_monthly_gifts,
-      transactions.total_monthly_revenue,
-      transactions.total_monthly_gifts,
-      transactions.objective,
-      transactions.campaign,
-      transactions.campaign_label,
-      transactions.audience,
-      transactions.appeal,
-      transactions.source_code,
-      subscribes.subscribes
-FROM {{ ref(campaigns) }} campaigns
-FULL JOIN {{ ref(impressions) }} impressions
-  ON campaigns.message_id = impressions.message_id
-FULL JOIN {{ ref(clicks) }} clicks
-  ON impressions.message_id = clicks.message_id
-  AND impressions.date_timestamp = clicks.date_timestamp
-FULL JOIN {{ ref(spends) }} spend
-  ON impressions.message_id = spend.message_id
-  AND impressions.date_timestamp = spend.date_timestamp
-FULL JOIN {{ ref(transactions) }} transactions
-  ON impressions.message_id = transactions.message_id
-  AND impressions.date_timestamp = transactions.date_timestamp
-FULL JOIN {{ ref(subscribes) }} subscribes
-  ON impressions.message_id = subscribes.message_id
-  AND impressions.date_timestamp = subscribes.date_timestamp
+    campaigns="stg_paidmedia_campaigns_unioned",
+    impressions="stg_paidmedia_impressions_daily_rollup_unioned",
+    clicks="stg_paidmedia_clicks_daily_rollup_unioned",
+    spends="stg_paidmedia_spends_daily_rollup_unioned",
+    transactions="stg_paidmedia_transactions_sourced_daily_rollup_unioned",
+    subscribes="stg_paidmedia_subscribes_daily_rollup_unioned"
+) %}
+select
+    coalesce(campaigns.message_id, impressions.message_id) as message_id,
+    campaigns.campaign_id,
+    coalesce(
+        campaigns.channel,
+        regexp_extract(
+            impressions._dbt_source_relation, 'stg_[a-z]+_([a-z_]+)_paidmedia'
+        )
+    ) as channel,
+    campaigns.channel_category,
+    campaigns.channel_type,
+    campaigns.campaign_name,
+    campaigns.crm_entity,
+    campaigns.source_code_entity,
+    case
+        when
+            (
+                campaigns.crm_entity is not null
+                and campaigns.source_code_entity is not null
+            )
+        then concat(campaigns.crm_entity, '-', campaigns.source_code_entity)
+        else coalesce(campaigns.crm_entity, campaigns.source_code_entity)
+    end as best_guess_entity,
+    campaigns.preview_url,
+    impressions.date_timestamp,
+    impressions.total_impressions,
+    impressions.unique_impressions,
+    clicks.total_clicks,
+    clicks.unique_clicks,
+    spend.spend_amount,
+    transactions.total_revenue,
+    transactions.total_gifts,
+    transactions.total_donors,
+    transactions.one_time_revenue,
+    transactions.one_time_gifts,
+    transactions.new_monthly_revenue,
+    transactions.new_monthly_gifts,
+    transactions.total_monthly_revenue,
+    transactions.total_monthly_gifts,
+    transactions.objective,
+    transactions.campaign,
+    transactions.campaign_label,
+    transactions.audience,
+    transactions.appeal,
+    transactions.source_code,
+    subscribes.subscribes
+from {{ ref(campaigns) }} campaigns
+full join
+    {{ ref(impressions) }} impressions on campaigns.message_id = impressions.message_id
+full join
+    {{ ref(clicks) }} clicks
+    on impressions.message_id = clicks.message_id
+    and impressions.date_timestamp = clicks.date_timestamp
+full join
+    {{ ref(spends) }} spend
+    on impressions.message_id = spend.message_id
+    and impressions.date_timestamp = spend.date_timestamp
+full join
+    {{ ref(transactions) }} transactions
+    on impressions.message_id = transactions.message_id
+    and impressions.date_timestamp = transactions.date_timestamp
+full join
+    {{ ref(subscribes) }} subscribes
+    on impressions.message_id = subscribes.message_id
+    and impressions.date_timestamp = subscribes.date_timestamp
 {% endmacro %}

--- a/macros/paidmedia/staging/stg_paidmedia_campaigns_unioned.sql
+++ b/macros/paidmedia/staging/stg_paidmedia_campaigns_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_paidmedia_campaigns_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_paidmedia_campaigns$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_paidmedia_campaigns$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/paidmedia/staging/stg_paidmedia_clicks_daily_rollup_unioned.sql
+++ b/macros/paidmedia/staging/stg_paidmedia_clicks_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_paidmedia_clicks_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_paidmedia_clicks_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_paidmedia_clicks_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/paidmedia/staging/stg_paidmedia_impressions_daily_rollup_unioned.sql
+++ b/macros/paidmedia/staging/stg_paidmedia_impressions_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_paidmedia_impressions_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_paidmedia_impressions_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_paidmedia_impressions_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/paidmedia/staging/stg_paidmedia_spends_daily_rollup_unioned.sql
+++ b/macros/paidmedia/staging/stg_paidmedia_spends_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_paidmedia_spends_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_paidmedia_spends_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_paidmedia_spends_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/paidmedia/staging/stg_paidmedia_subscribes_daily_rollup_unioned.sql
+++ b/macros/paidmedia/staging/stg_paidmedia_subscribes_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_paidmedia_subscribes_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_paidmedia_subscribes_daily_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_paidmedia_subscribes_daily_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/paidmedia/staging/stg_paidmedia_transactions_sourced_daily_rollup_unioned.sql
+++ b/macros/paidmedia/staging/stg_paidmedia_transactions_sourced_daily_rollup_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_paidmedia_transactions_sourced_daily_rollup_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_paidmedia_transactions_sourced_rollup$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_paidmedia_transactions_sourced_rollup$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/paidmedia_adhoc_pacing_actuals/marts/mart_paidmedia_adhoc_pacing_actuals.sql
+++ b/macros/paidmedia_adhoc_pacing_actuals/marts/mart_paidmedia_adhoc_pacing_actuals.sql
@@ -1,21 +1,21 @@
 {% macro create_mart_paidmedia_adhoc_pacing_actuals(
-    reference_name='stg_paidmedia_pacing_actuals_campaigns_rollup_join') %}
+    reference_name="stg_paidmedia_pacing_actuals_campaigns_rollup_join"
+) %}
 
-SELECT 
-date_day,
-date_trunc(date_day, WEEK) as date_week_sunday,
-date_trunc(date_day, WEEK(MONDAY)) as date_week_monday,
-date_trunc(date_day, MONTH) as date_month,
-date_trunc(date_day, QUARTER) as date_quarter,
-objective,
-channel,
-channel_type,
-case when platform = 'ad' then 'bing_ad' else platform end as platform,
-campaign_name,
-actual_spend,
-actual_revenue
+select
+    date_day,
+    date_trunc(date_day, week) as date_week_sunday,
+    date_trunc(date_day, week(monday)) as date_week_monday,
+    date_trunc(date_day, month) as date_month,
+    date_trunc(date_day, quarter) as date_quarter,
+    objective,
+    channel,
+    channel_type,
+    case when platform = 'ad' then 'bing_ad' else platform end as platform,
+    campaign_name,
+    actual_spend,
+    actual_revenue
 
- FROM {{ref(reference_name)}}
-
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/paidmedia_adhoc_pacing_actuals/staging/stg_paidmedia_pacing_actuals_campaigns.sql
+++ b/macros/paidmedia_adhoc_pacing_actuals/staging/stg_paidmedia_pacing_actuals_campaigns.sql
@@ -1,14 +1,14 @@
 {% macro create_stg_paidmedia_pacing_actuals_campaigns(
-    reference_name='mart_paidmedia_daily_revenue_performance') %}
+    reference_name="mart_paidmedia_daily_revenue_performance"
+) %}
 
-SELECT
-campaign_name,
-channel as platform,
-max(objective) as objective,
-max(channel_category) as channel,
-max(channel_type) as channel_type
-FROM {{ ref(reference_name) }}
-GROUP BY 1, 2
-
+select
+    campaign_name,
+    channel as platform,
+    max(objective) as objective,
+    max(channel_category) as channel,
+    max(channel_type) as channel_type
+from {{ ref(reference_name) }}
+group by 1, 2
 
 {% endmacro %}

--- a/macros/paidmedia_adhoc_pacing_actuals/staging/stg_paidmedia_pacing_actuals_campaigns_rollup_join.sql
+++ b/macros/paidmedia_adhoc_pacing_actuals/staging/stg_paidmedia_pacing_actuals_campaigns_rollup_join.sql
@@ -1,21 +1,22 @@
 {% macro create_stg_paidmedia_pacing_actuals_campaigns_rollup_join(
-    campaigns='stg_paidmedia_pacing_actuals_campaigns',
-    rollups='stg_paidmedia_pacing_actuals_rollup'
-    ) %}
+    campaigns="stg_paidmedia_pacing_actuals_campaigns",
+    rollups="stg_paidmedia_pacing_actuals_rollup"
+) %}
 
-SELECT
-rollups.date_day,
-campaigns.objective,
-campaigns.channel,
-rollups.platform,
-campaigns.channel_type,
-rollups.campaign_name,
-rollups.actual_spend,
-rollups.actual_revenue
+select
+    rollups.date_day,
+    campaigns.objective,
+    campaigns.channel,
+    rollups.platform,
+    campaigns.channel_type,
+    rollups.campaign_name,
+    rollups.actual_spend,
+    rollups.actual_revenue
 
-FROM {{ref(rollups)}} rollups
-LEFT JOIN {{ref(campaigns)}} campaigns
-on lower(rollups.campaign_name) = lower(campaigns.campaign_name)
-and lower(rollups.platform) = lower(campaigns.platform)
+from {{ ref(rollups) }} rollups
+left join
+    {{ ref(campaigns) }} campaigns
+    on lower(rollups.campaign_name) = lower(campaigns.campaign_name)
+    and lower(rollups.platform) = lower(campaigns.platform)
 
 {% endmacro %}

--- a/macros/paidmedia_adhoc_pacing_actuals/staging/stg_paidmedia_pacing_actuals_rollup.sql
+++ b/macros/paidmedia_adhoc_pacing_actuals/staging/stg_paidmedia_pacing_actuals_rollup.sql
@@ -1,15 +1,14 @@
 {% macro create_stg_paidmedia_pacing_actuals_rollup(
-    reference_name='mart_paidmedia_daily_revenue_performance') %}
-SELECT
-safe_cast(date_timestamp as date) as date_day,
-channel as platform,
-campaign_name,
-sum(spend_amount) as actual_spend,
-sum(total_revenue) as actual_revenue
+    reference_name="mart_paidmedia_daily_revenue_performance"
+) %}
+select
+    safe_cast(date_timestamp as date) as date_day,
+    channel as platform,
+    campaign_name,
+    sum(spend_amount) as actual_spend,
+    sum(total_revenue) as actual_revenue
 
-FROM {{ref(reference_name)}}
-GROUP BY 1, 2, 3
-
-
+from {{ ref(reference_name) }}
+group by 1, 2, 3
 
 {% endmacro %}

--- a/macros/paidmedia_goals/marts/mart_paidmedia_monthly_goals_and_actuals.sql
+++ b/macros/paidmedia_goals/marts/mart_paidmedia_monthly_goals_and_actuals.sql
@@ -1,6 +1,6 @@
 {% macro create_mart_paidmedia_monthly_goals_and_actuals(
-    reference_name='stg_paidmedia_actuals_goals_unioned_transform') %}
-SELECT DISTINCT * FROM {{ ref(reference_name)}}
-
+    reference_name="stg_paidmedia_actuals_goals_unioned_transform"
+) %}
+select distinct * from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/paidmedia_goals/staging/stg_adhoc_google_spreadsheets_paidmedia_monthly_goals.sql
+++ b/macros/paidmedia_goals/staging/stg_adhoc_google_spreadsheets_paidmedia_monthly_goals.sql
@@ -1,10 +1,16 @@
 {% macro create_stg_adhoc_google_spreadsheets_paidmedia_monthly_goals() %}
-SELECT 
-SAFE_CAST(INITCAP(month) || ' ' || year as STRING) as month_year,
-SAFE_CAST(lower(objective) as STRING) as objective,
-SAFE_CAST(lower(channel) as STRING) as channel,
-SAFE_CAST(lower(platform) as STRING) as platform,
-SAFE_CAST(projected_spend AS float64) as projected_spend,
-SAFE_CAST(projected_revenue as float64) as projected_revenue
- FROM {{ source('adhoc_google_spreadsheets_paidmedia_goals','spreadsheet_paidmedia_monthly_goals') }}
+select
+    safe_cast(initcap(month) || ' ' || year as string) as month_year,
+    safe_cast(lower(objective) as string) as objective,
+    safe_cast(lower(channel) as string) as channel,
+    safe_cast(lower(platform) as string) as platform,
+    safe_cast(projected_spend as float64) as projected_spend,
+    safe_cast(projected_revenue as float64) as projected_revenue
+from
+    {{
+        source(
+            "adhoc_google_spreadsheets_paidmedia_goals",
+            "spreadsheet_paidmedia_monthly_goals",
+        )
+    }}
 {% endmacro %}

--- a/macros/paidmedia_goals/staging/stg_paidmedia_actuals_goals_unioned.sql
+++ b/macros/paidmedia_goals/staging/stg_paidmedia_actuals_goals_unioned.sql
@@ -1,7 +1,10 @@
-
 {% macro create_stg_paidmedia_actuals_goals_unioned() %}
-{{ dbt_utils.union_relations(
-relations=[ref('stg_adhoc_google_spreadsheets_paidmedia_monthly_goals'),
- ref('stg_paidmedia_goals_monthly_actuals_rollup')]
-) }}
+{{
+    dbt_utils.union_relations(
+        relations=[
+            ref("stg_adhoc_google_spreadsheets_paidmedia_monthly_goals"),
+            ref("stg_paidmedia_goals_monthly_actuals_rollup"),
+        ]
+    )
+}}
 {% endmacro %}

--- a/macros/paidmedia_goals/staging/stg_paidmedia_actuals_goals_unioned_transform.sql
+++ b/macros/paidmedia_goals/staging/stg_paidmedia_actuals_goals_unioned_transform.sql
@@ -1,39 +1,69 @@
 {% macro create_stg_paidmedia_actuals_goals_unioned_transform(
-    reference_name='stg_paidmedia_actuals_goals_unioned') %}
-SELECT
-     month_year,
-     PARSE_DATE('%B %Y', month_year) as month_year_date,
-     case when regexp_contains(channel, 'soc') = true then 'Social'
-     when regexp_contains(platform, 'soc') = true then 'Social'
-     when regexp_contains(channel, 'sear') = true then 'Search'
-     when regexp_contains(platform, 'sear') = true then 'Search'
-     when regexp_contains(channel, 'disp') = true then 'Display'
-     when regexp_contains(platform, 'disp') = true then 'Display'
-     when regexp_contains(channel, 'vid') = true then 'Display'
-     when regexp_contains(platform, 'vid') = true then 'Display'
-     when regexp_contains(channel, 'youtube') = true then 'Display'
-     when regexp_contains(platform, 'youtube') = true then 'Display'
-     else channel end as channel,
-    case when regexp_contains(objective, 'awar') = true then 'Awareness'
-    when regexp_contains(objective, 'acq') = true then 'Acquisition'
-    when regexp_contains(objective, 'fun') = true then 'Fundraising'
-    else objective end as objective,
-      case when regexp_contains(platform, 'goog') = true then 'Google'
-      when regexp_contains(platform, 'bing') = true then 'Bing'
-      when regexp_contains(platform, 'facebook') = true then 'Facebook'
-      when regexp_contains(platform, 'fb') = true then 'Facebook'
-      when regexp_contains(platform, 'instagram') = true then 'Facebook'
-      when regexp_contains(platform, 'youtube') = true then 'Google'
-      when regexp_contains(platform, 'yt') = true then 'Google'
-      when regexp_contains(platform, 'linked') = true then 'LinkedIn'
-      when regexp_contains(platform, 'yahoo') = true then 'Yahoo'
-      when platform = 'ad' then 'Bing'
-        else platform end as platform,
-      sum(actual_spend) as actual_spend,
-      sum(actual_revenue) as actual_revenue,
-      sum(actual_donations) as actual_donations,
-      sum(projected_revenue) as projected_revenue,
-      sum(projected_spend) as projected_spend
-FROM {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3, 4, 5
+    reference_name="stg_paidmedia_actuals_goals_unioned"
+) %}
+select
+    month_year,
+    parse_date('%B %Y', month_year) as month_year_date,
+    case
+        when regexp_contains(channel, 'soc') = true
+        then 'Social'
+        when regexp_contains(platform, 'soc') = true
+        then 'Social'
+        when regexp_contains(channel, 'sear') = true
+        then 'Search'
+        when regexp_contains(platform, 'sear') = true
+        then 'Search'
+        when regexp_contains(channel, 'disp') = true
+        then 'Display'
+        when regexp_contains(platform, 'disp') = true
+        then 'Display'
+        when regexp_contains(channel, 'vid') = true
+        then 'Display'
+        when regexp_contains(platform, 'vid') = true
+        then 'Display'
+        when regexp_contains(channel, 'youtube') = true
+        then 'Display'
+        when regexp_contains(platform, 'youtube') = true
+        then 'Display'
+        else channel
+    end as channel,
+    case
+        when regexp_contains(objective, 'awar') = true
+        then 'Awareness'
+        when regexp_contains(objective, 'acq') = true
+        then 'Acquisition'
+        when regexp_contains(objective, 'fun') = true
+        then 'Fundraising'
+        else objective
+    end as objective,
+    case
+        when regexp_contains(platform, 'goog') = true
+        then 'Google'
+        when regexp_contains(platform, 'bing') = true
+        then 'Bing'
+        when regexp_contains(platform, 'facebook') = true
+        then 'Facebook'
+        when regexp_contains(platform, 'fb') = true
+        then 'Facebook'
+        when regexp_contains(platform, 'instagram') = true
+        then 'Facebook'
+        when regexp_contains(platform, 'youtube') = true
+        then 'Google'
+        when regexp_contains(platform, 'yt') = true
+        then 'Google'
+        when regexp_contains(platform, 'linked') = true
+        then 'LinkedIn'
+        when regexp_contains(platform, 'yahoo') = true
+        then 'Yahoo'
+        when platform = 'ad'
+        then 'Bing'
+        else platform
+    end as platform,
+    sum(actual_spend) as actual_spend,
+    sum(actual_revenue) as actual_revenue,
+    sum(actual_donations) as actual_donations,
+    sum(projected_revenue) as projected_revenue,
+    sum(projected_spend) as projected_spend
+from {{ ref(reference_name) }}
+group by 1, 2, 3, 4, 5
 {% endmacro %}

--- a/macros/paidmedia_goals/staging/stg_paidmedia_goals_monthly_actuals_rollup.sql
+++ b/macros/paidmedia_goals/staging/stg_paidmedia_goals_monthly_actuals_rollup.sql
@@ -1,15 +1,18 @@
 {% macro create_stg_paidmedia_goals_monthly_actuals_rollup(
-    reference_name='mart_paidmedia_daily_revenue_performance') %}
-SELECT
-     FORMAT_DATE('%B %Y', CAST(date_timestamp AS date)) as month_year, 
-     case when channel_type is not null then SAFE_CAST(lower(channel_category) || ' ' || lower(channel_type) as string)
-      else SAFE_CAST(lower(channel_category) as string) end
-      as channel,
-      SAFE_CAST(lower(objective) as string) as objective,
-      SAFE_CAST(lower(channel) as string) as platform,
-      SAFE_CAST(SUM(spend_amount) as float64) as actual_spend,
-      SAFE_CAST(SUM(total_revenue) as float64) as actual_revenue,
-      SAFE_CAST(SUM(total_gifts) as float64) as actual_donations
-FROM {{ ref(reference_name) }} 
-GROUP BY 1, 2, 3, 4
+    reference_name="mart_paidmedia_daily_revenue_performance"
+) %}
+select
+    format_date('%B %Y', cast(date_timestamp as date)) as month_year,
+    case
+        when channel_type is not null
+        then safe_cast(lower(channel_category) || ' ' || lower(channel_type) as string)
+        else safe_cast(lower(channel_category) as string)
+    end as channel,
+    safe_cast(lower(objective) as string) as objective,
+    safe_cast(lower(channel) as string) as platform,
+    safe_cast(sum(spend_amount) as float64) as actual_spend,
+    safe_cast(sum(total_revenue) as float64) as actual_revenue,
+    safe_cast(sum(total_gifts) as float64) as actual_donations
+from {{ ref(reference_name) }}
+group by 1, 2, 3, 4
 {% endmacro %}

--- a/macros/paidmedia_pacing/marts/mart_paidmedia_pacing_budget_actuals_by_day.sql
+++ b/macros/paidmedia_pacing/marts/mart_paidmedia_pacing_budget_actuals_by_day.sql
@@ -1,36 +1,35 @@
 {% macro create_mart_paidmedia_pacing_budget_actuals_by_day(
-    jobs='stg_paidmedia_actuals_campaign_jobs',
-    daily='stg_paidmedia_actuals_budget_by_day_and_campaign_join'
+    jobs="stg_paidmedia_actuals_campaign_jobs",
+    daily="stg_paidmedia_actuals_budget_by_day_and_campaign_join"
 ) %}
 
+with
+    base as (
+        select
+            daily.date_day,
+            daily.campaign_start_date,
+            daily.campaign_end_date,
+            daily.campaign_name,
+            daily.daily_spend,
+            daily.cumulative_spend,
+            daily.spend_pace,
+            daily.daily_budget,
+            daily.cumulative_budget,
+            daily.remaining_budget,
+            daily.total_budget,
+            daily.budget_pace,
+            daily.descriptions,
+            jobs.channel,
+            jobs.channel_category,
+            jobs.channel_type,
+            jobs.objective
 
-with base as (
-SELECT
-daily.date_day,
-daily.campaign_start_date,
-daily.campaign_end_date,
-daily.campaign_name,
-daily.daily_spend,
-daily.cumulative_spend,
-daily.spend_pace,
-daily.daily_budget,
-daily.cumulative_budget,
-daily.remaining_budget,
-daily.total_budget,
-daily.budget_pace,
-daily.descriptions,
-jobs.channel,
-jobs.channel_category,
-jobs.channel_type,
-jobs.objective
+        from {{ ref(daily) }} daily
+        left join {{ ref(jobs) }} jobs on daily.campaign_name = jobs.campaign_name
+        where daily.campaign_name is not null and daily.campaign_start_date is not null
+    )
 
-FROM {{ref(daily)}} daily
-LEFT JOIN {{ref(jobs)}} jobs
-ON daily.campaign_name = jobs.campaign_name
-WHERE daily.campaign_name IS NOT NULL
-and daily.campaign_start_date IS NOT NULL)
-
-select distinct * from base
-
+select distinct *
+from base
 
 {% endmacro %}

--- a/macros/paidmedia_pacing/staging/stg_adhoc_google_spreadsheets_paidmedia_pacing_budget.sql
+++ b/macros/paidmedia_pacing/staging/stg_adhoc_google_spreadsheets_paidmedia_pacing_budget.sql
@@ -1,9 +1,15 @@
 {% macro create_stg_adhoc_google_spreadsheets_paidmedia_pacing_budget() %}
-SELECT 
-SAFE_CAST(start_date as date) as campaign_start_date,
-SAFE_CAST(end_date as date) as campaign_end_date,
-SAFE_CAST(lower(campaign_name) as STRING) as campaign_name,
-SAFE_CAST(budget AS float64) as budget,
-SAFE_CAST(description as string) as descriptions
- FROM {{ source('adhoc_google_spreadsheets_paidmedia_pacing','spreadsheet_paidmedia_pacing_budget') }}
+select
+    safe_cast(start_date as date) as campaign_start_date,
+    safe_cast(end_date as date) as campaign_end_date,
+    safe_cast(lower(campaign_name) as string) as campaign_name,
+    safe_cast(budget as float64) as budget,
+    safe_cast(description as string) as descriptions
+from
+    {{
+        source(
+            "adhoc_google_spreadsheets_paidmedia_pacing",
+            "spreadsheet_paidmedia_pacing_budget",
+        )
+    }}
 {% endmacro %}

--- a/macros/paidmedia_pacing/staging/stg_paidmedia_actuals_budget_by_day_and_campaign_join.sql
+++ b/macros/paidmedia_pacing/staging/stg_paidmedia_actuals_budget_by_day_and_campaign_join.sql
@@ -1,26 +1,28 @@
 {% macro create_stg_paidmedia_actuals_budget_by_day_and_campaign_join(
-    actuals='stg_paidmedia_pacing_actuals_campaign_and_date_rollup',
-    budget='stg_paidmedia_pacing_budget_datespine_details_join'
+    actuals="stg_paidmedia_pacing_actuals_campaign_and_date_rollup",
+    budget="stg_paidmedia_pacing_budget_datespine_details_join"
 ) %}
 
-SELECT
-COALESCE(actuals.date_day, budget.date_day) as date_day,
-COALESCE(actuals.campaign_name, budget.campaign_name) as campaign_name,
-actuals.daily_spend,
-actuals.cumulative_spend,
-budget.daily_budget,
-COALESCE(budget.total_budget,0) - COALESCE(actuals.daily_spend,0) as remaining_budget,
-COALESCE(actuals.cumulative_spend / budget.total_budget, 0) as spend_pace,
-COALESCE(budget.cumulative_budget / budget.total_budget, 0) as budget_pace,
-budget.cumulative_budget,
-budget.total_budget,
-budget.campaign_start_date,
-budget.campaign_end_date,
-budget.descriptions
+select
+    coalesce(actuals.date_day, budget.date_day) as date_day,
+    coalesce(actuals.campaign_name, budget.campaign_name) as campaign_name,
+    actuals.daily_spend,
+    actuals.cumulative_spend,
+    budget.daily_budget,
+    coalesce(budget.total_budget, 0)
+    - coalesce(actuals.daily_spend, 0) as remaining_budget,
+    coalesce(actuals.cumulative_spend / budget.total_budget, 0) as spend_pace,
+    coalesce(budget.cumulative_budget / budget.total_budget, 0) as budget_pace,
+    budget.cumulative_budget,
+    budget.total_budget,
+    budget.campaign_start_date,
+    budget.campaign_end_date,
+    budget.descriptions
 
-FROM {{ref(actuals)}} actuals
-FULL OUTER JOIN {{ref(budget)}} budget
-ON actuals.date_day = budget.date_day
-and actuals.campaign_name = budget.campaign_name
+from {{ ref(actuals) }} actuals
+full outer join
+    {{ ref(budget) }} budget
+    on actuals.date_day = budget.date_day
+    and actuals.campaign_name = budget.campaign_name
 
 {% endmacro %}

--- a/macros/paidmedia_pacing/staging/stg_paidmedia_actuals_campaign_jobs.sql
+++ b/macros/paidmedia_pacing/staging/stg_paidmedia_actuals_campaign_jobs.sql
@@ -1,13 +1,14 @@
 {% macro create_stg_paidmedia_actuals_campaign_jobs(
-    reference_name='mart_paidmedia_daily_revenue_performance') %}
-SELECT
-distinct(lower(campaign_name)) as campaign_name,
-channel,
-channel_category,
-channel_type,
-objective
+    reference_name="mart_paidmedia_daily_revenue_performance"
+) %}
+select distinct
+    (lower(campaign_name)) as campaign_name,
+    channel,
+    channel_category,
+    channel_type,
+    objective
 
-FROM {{ref(reference_name)}} 
-WHERE campaign_name is not null
+from {{ ref(reference_name) }}
+where campaign_name is not null
 
 {% endmacro %}

--- a/macros/paidmedia_pacing/staging/stg_paidmedia_pacing_actuals_campaign_and_date_rollup.sql
+++ b/macros/paidmedia_pacing/staging/stg_paidmedia_pacing_actuals_campaign_and_date_rollup.sql
@@ -1,42 +1,43 @@
 {% macro create_stg_paidmedia_pacing_actuals_campaign_and_date_rollup(
-    reference_name='mart_paidmedia_daily_revenue_performance') %}
+    reference_name="mart_paidmedia_daily_revenue_performance"
+) %}
 
-with safe_casting as (
-SELECT
-safe_cast(date_timestamp as date) as date_day,
-lower(safe_cast(campaign_name as string)) as campaign_name,
-safe_cast(spend_amount as int) as spend_amount
-FROM {{ref(reference_name)}}
+with
+    safe_casting as (
+        select
+            safe_cast(date_timestamp as date) as date_day,
+            lower(safe_cast(campaign_name as string)) as campaign_name,
+            safe_cast(spend_amount as int) as spend_amount
+        from {{ ref(reference_name) }}
 
-)
+    ),
+    daily_spend as (
 
-, daily_spend as (
+        select date_day, campaign_name, sum(spend_amount) as daily_spend
 
-SELECT
-date_day,
-campaign_name,
-sum(spend_amount) as daily_spend
+        from safe_casting
+        group by 1, 2
+    ),
+    cumulative_spend as (
+        select
+            date_day,
+            campaign_name,
+            sum(spend_amount) over (
+                partition by campaign_name order by date_day
+            ) as cumulative_spend
+        from safe_casting
 
-FROM safe_casting
-GROUP BY 1, 2)
+    )
 
-, cumulative_spend as (
-SELECT 
-date_day,
-campaign_name,
-sum(spend_amount) over (partition by campaign_name order by date_day) as cumulative_spend
-from safe_casting
-
-)
-
-SELECT
-daily_spend.date_day,
-daily_spend.campaign_name,
-daily_spend.daily_spend,
-cumulative_spend.cumulative_spend
-from daily_spend 
-full outer join cumulative_spend
-on daily_spend.date_day = cumulative_spend.date_day
-and daily_spend.campaign_name = cumulative_spend.campaign_name
+select
+    daily_spend.date_day,
+    daily_spend.campaign_name,
+    daily_spend.daily_spend,
+    cumulative_spend.cumulative_spend
+from daily_spend
+full outer join
+    cumulative_spend
+    on daily_spend.date_day = cumulative_spend.date_day
+    and daily_spend.campaign_name = cumulative_spend.campaign_name
 
 {% endmacro %}

--- a/macros/paidmedia_pacing/staging/stg_paidmedia_pacing_budget_datespine_details_join.sql
+++ b/macros/paidmedia_pacing/staging/stg_paidmedia_pacing_budget_datespine_details_join.sql
@@ -1,21 +1,21 @@
 {% macro create_stg_paidmedia_pacing_budget_datespine_details_join(
-    datespine='stg_paidmedia_pacing_budget_with_datespine',
-    details='stg_adhoc_google_spreadsheets_paidmedia_pacing_budget'
+    datespine="stg_paidmedia_pacing_budget_with_datespine",
+    details="stg_adhoc_google_spreadsheets_paidmedia_pacing_budget"
 ) %}
 
-SELECT 
-datespine.date_day,
-details.campaign_start_date,
-details.campaign_end_date,
-datespine.campaign_name,
-datespine.daily_budget,
-sum(datespine.daily_budget) over (partition by datespine.campaign_name order by datespine.date_day) as cumulative_budget,
-details.descriptions,
-details.budget as total_budget
+select
+    datespine.date_day,
+    details.campaign_start_date,
+    details.campaign_end_date,
+    datespine.campaign_name,
+    datespine.daily_budget,
+    sum(datespine.daily_budget) over (
+        partition by datespine.campaign_name order by datespine.date_day
+    ) as cumulative_budget,
+    details.descriptions,
+    details.budget as total_budget
 
-FROM {{ref(datespine)}} datespine
-LEFT JOIN 
-{{ref(details)}} details 
-ON datespine.campaign_name = details.campaign_name
+from {{ ref(datespine) }} datespine
+left join {{ ref(details) }} details on datespine.campaign_name = details.campaign_name
 
-{% endmacro %} 
+{% endmacro %}

--- a/macros/paidmedia_pacing/staging/stg_paidmedia_pacing_budget_with_datespine.sql
+++ b/macros/paidmedia_pacing/staging/stg_paidmedia_pacing_budget_with_datespine.sql
@@ -1,29 +1,26 @@
 {% macro create_stg_paidmedia_pacing_budget_with_datespine() %}
 
-with base as (
+with
+    base as (
 
-SELECT 
-campaign_start_date,
-campaign_end_date,
-generate_date_array(campaign_start_date, campaign_end_date) as date_day,
-campaign_name,
-SAFE_DIVIDE(budget , (date_diff(campaign_end_date, campaign_start_date, day)+1)) as daily_budget,
-descriptions 
-FROM {{ ref('stg_adhoc_google_spreadsheets_paidmedia_pacing_budget') }}
+        select
+            campaign_start_date,
+            campaign_end_date,
+            generate_date_array(campaign_start_date, campaign_end_date) as date_day,
+            campaign_name,
+            safe_divide(
+                budget, (date_diff(campaign_end_date, campaign_start_date, day) + 1)
+            ) as daily_budget,
+            descriptions
+        from {{ ref("stg_adhoc_google_spreadsheets_paidmedia_pacing_budget") }}
 
-)
+    )
 
-
-SELECT 
-date_day, 
-campaign_name,
-daily_budget
- FROM base
+select date_day, campaign_name, daily_budget
+from base
 -- cross join with unnested date_day array to create a row for each day
-CROSS JOIN UNNEST(date_day) as date_day
+cross join unnest(date_day) as date_day
 -- filter out dates that are outside of the campaign start and end dates
-WHERE date_day >= campaign_start_date AND date_day <= campaign_end_date
+where date_day >= campaign_start_date and date_day <= campaign_end_date
 
-
-{% endmacro %} 
-
+{% endmacro %}

--- a/macros/stitch_sfmc_bbcrm_transactions/staging/stg_src_stitch_sfmc_bbcrm_transaction.sql
+++ b/macros/stitch_sfmc_bbcrm_transactions/staging/stg_src_stitch_sfmc_bbcrm_transaction.sql
@@ -1,17 +1,20 @@
 {% macro create_stg_src_stitch_sfmc_bbcrm_transaction() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^revenue$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^revenue$",
     is_source=True,
-  source_name='src_stitch_bbcrm',
-  schema_to_search='src_stitch_bbcrm_authorized') %}
+    source_name="src_stitch_bbcrm",
+    schema_to_search="src_stitch_bbcrm_authorized",
+) %}
 
-with revenue as (
-Select DISTINCT
+with
+    revenue as (
+        select distinct
             __bbcrmlookupid_ as bbcrmlookupid,
             constituentsystemrecordid as constituentsystemrecordid,
-            SAFE_CAST(statuscode as string) as statuscode,
-            SAFE_CAST(recordid as string) as recordid,
+            safe_cast(statuscode as string) as statuscode,
+            safe_cast(recordid as string) as recordid,
             revenue_id as revenue_id,
-            SAFE_CAST(transaction_date as datetime) as transaction_date,
+            safe_cast(transaction_date as datetime) as transaction_date,
             payment_method as payment_method,
             recognition_amount as amount,
             inbound_channel as inbound_channel,
@@ -25,12 +28,13 @@ Select DISTINCT
             application as application,
             vendor_order_number as vendor_order_number,
             revenue_platform as revenue_platform,
-            SAFE_CAST(sfmc_dateadded as datetime) as sfmc_dateadded,
-            SAFE_CAST(sfmc_updatedate as datetime) as sfmc_updatedate
+            safe_cast(sfmc_dateadded as datetime) as sfmc_dateadded,
+            safe_cast(sfmc_updatedate as datetime) as sfmc_updatedate
 
         from ({{ dbt_utils.union_relations(relations) }})
 
-), current_fiscal_ranked as (
+    ),
+    current_fiscal_ranked as (
 
         select
             *,
@@ -40,10 +44,13 @@ Select DISTINCT
         from revenue
 
     ),
-    final as (select * except (row_num) from current_fiscal_ranked where row_num = 1 AND revenue_id != 'rev-44816929')
+    final as (
+        select * except (row_num)
+        from current_fiscal_ranked
+        where row_num = 1 and revenue_id != 'rev-44816929'
+    )
 select *
 from final
 where cast(transaction_date as datetime) < current_datetime()
 
 {% endmacro %}
-

--- a/macros/stitch_sfmc_bbcrm_transactions/staging/stg_stitch_sfmc_bbcrm_transaction.sql
+++ b/macros/stitch_sfmc_bbcrm_transactions/staging/stg_stitch_sfmc_bbcrm_transaction.sql
@@ -1,19 +1,20 @@
 {% macro create_stg_stitch_sfmc_bbcrm_transaction(
-    reference_name = 'stg_src_stitch_sfmc_bbcrm_transaction'
+    reference_name="stg_src_stitch_sfmc_bbcrm_transaction"
 ) %}
 
-Select
-        revenue_id as transaction_id,
-        bbcrmlookupid as person_id,
-        initial_market_source as source_code,
-        SAFE_CAST('sfmc_bbcrm' as STRING) as crm,
-        SAFE_CAST(REGEXP_EXTRACT(initial_market_source,r"sfmc(\d{6})") AS INT) as message_id,
-        transaction_date,
-        amount,
-        appeal,
-        appeal_business_unit,
-        application
-        from {{ref(reference_name)}}
+select
+    revenue_id as transaction_id,
+    bbcrmlookupid as person_id,
+    initial_market_source as source_code,
+    safe_cast('sfmc_bbcrm' as string) as crm,
+    safe_cast(
+        regexp_extract(initial_market_source, r"sfmc(\d{6})") as int
+    ) as message_id,
+    transaction_date,
+    amount,
+    appeal,
+    appeal_business_unit,
+    application
+from {{ ref(reference_name) }}
 
 {% endmacro %}
-

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
@@ -1,27 +1,31 @@
 {% macro create_stg_src_stitch_email_action() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^click$',
-  is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^click$",
+    is_source=True,
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
+select distinct
+    cast(__accountid_ as int64) as account_id,
+    cast(oybaccountid as int64) as oyb_account_id,
+    cast(jobid as int64) as job_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    domain,
+    url,
+    linkname as link_name,
+    linkcontent as link_content,
+    cast(isunique as bool) as is_unique,
+    triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+    triggeredsendcustomerkey as triggered_send_customer_key
 
-Select distinct
-        CAST(__accountid_ AS INT64) as account_id,
-        CAST(oybaccountid AS INT64) as oyb_account_id,
-        CAST(jobid AS INT64) as job_id,
-        CAST(listid AS INT64) as list_id,
-        CAST(batchid AS INT64) as batch_id,
-        CAST(subscriberid AS INT64) as subscriber_id,
-        subscriberkey as subscriber_key,
-        datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt,
-        domain,
-        url,
-        linkname as link_name,
-        linkcontent as link_content,
-        CAST(isunique AS BOOL) as is_unique,
-        triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-        triggeredsendcustomerkey as triggered_send_customer_key
-
-    from ({{ dbt_utils.union_relations(relations) }})
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
@@ -1,31 +1,35 @@
 {% macro create_stg_src_stitch_email_bounce() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^bounce$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^bounce$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
-
-Select DISTINCT
-     CAST(__accountid_ AS INT64) as account_id
-    ,CAST(oybaccountid AS INT64) as oyb_account_id
-    ,CAST(jobid AS INT64) as job_id
-    ,CAST(listid AS INT64) as list_id
-    ,CAST(batchid AS INT64) as batch_id
-    ,CAST(subscriberid AS INT64) as subscriber_id
-    ,subscriberkey as subscriber_key
-    ,datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt
-    ,CAST(isunique as BOOL) as is_unique
-    ,domain as domain
-    ,CAST(bouncecategoryid as STRING) as bounce_category_id
-    ,bouncecategory as bounce_category
-    ,bouncesubcategoryid as bounce_subcategory_id
-    ,bouncesubcategory as bounce_subcategory
-    ,CAST(bouncetypeid as STRING) as bounce_type_id
-    ,bouncetype as bounce_type
-    ,CAST(smtpcode as STRING) as smtp_code
-    ,triggerersenddefinitionobjectID as triggerrer_send_definition_object_id
-    ,CAST(triggeredsendcustomerkey as STRING) as triggered_send_customer_key
-    , _sdc_received_at  as recieved_at
-    from ({{ dbt_utils.union_relations(relations) }})
+select distinct
+    cast(__accountid_ as int64) as account_id,
+    cast(oybaccountid as int64) as oyb_account_id,
+    cast(jobid as int64) as job_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    cast(isunique as bool) as is_unique,
+    domain as domain,
+    cast(bouncecategoryid as string) as bounce_category_id,
+    bouncecategory as bounce_category,
+    bouncesubcategoryid as bounce_subcategory_id,
+    bouncesubcategory as bounce_subcategory,
+    cast(bouncetypeid as string) as bounce_type_id,
+    bouncetype as bounce_type,
+    cast(smtpcode as string) as smtp_code,
+    triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+    cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
+    _sdc_received_at as recieved_at
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
@@ -1,27 +1,31 @@
 {% macro create_stg_src_stitch_email_click() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^click$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^click$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
-Select distinct
-        CAST(__accountid_ AS INT64) as account_id,
-        CAST(oybaccountid AS INT64) as oyb_account_id,
-        CAST(jobid AS INT64) as job_id,
-        CAST(listid AS INT64) as list_id,
-        CAST(batchid AS INT64) as batch_id,
-        CAST(subscriberid AS INT64) as subscriber_id,
-        subscriberkey as subscriber_key,
-        datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt,
-        domain,
-        url,
-        linkname as link_name,
-        linkcontent as link_content,
-        CAST(isunique AS BOOL) as is_unique,
-        triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-        triggeredsendcustomerkey as triggered_send_customer_key
+select distinct
+    cast(__accountid_ as int64) as account_id,
+    cast(oybaccountid as int64) as oyb_account_id,
+    cast(jobid as int64) as job_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    domain,
+    url,
+    linkname as link_name,
+    linkcontent as link_content,
+    cast(isunique as bool) as is_unique,
+    triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+    triggeredsendcustomerkey as triggered_send_customer_key
 
-
-    from ({{ dbt_utils.union_relations(relations) }})
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
@@ -1,21 +1,26 @@
 {% macro create_stg_src_stitch_email_complaint() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^complaint$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^complaint$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
 select distinct
-        CAST(__accountid_ AS INT64) as account_id
-        ,CAST(oybaccountid AS INT64) as oyb_account_id
-        ,CAST(jobid AS INT64) as job_id
-        ,CAST(listid AS INT64) as list_id
-        ,CAST(batchid AS INT64) as batch_id
-        ,CAST(subscriberid AS INT64) as subscriber_id
-        ,subscriberkey as subscriber_key
-        ,datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt
-        ,CAST(isunique AS BOOL) as is_unique
-        ,domain
+    cast(__accountid_ as int64) as account_id,
+    cast(oybaccountid as int64) as oyb_account_id,
+    cast(jobid as int64) as job_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    cast(isunique as bool) as is_unique,
+    domain
 
-    from ({{ dbt_utils.union_relations(relations) }})
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_job.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_job.sql
@@ -1,62 +1,119 @@
 {% macro create_stg_src_stitch_email_job() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^job$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^job$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
-SELECT distinct
-    CAST(__jobid_ AS INT64) as job_id
-    ,CAST(emailid AS INT64) as email_id
-    ,CAST(accountid AS INT64) as account_id
-    ,CAST(accountuserid AS INT64) as account_user_id
-    ,fromname as from_name
-    ,fromemail as from_email
-    ,( case
-        when length(schedtime) > 0 then datetime(CAST(CONCAT(Substr(schedtime,0,22)," America/New_York") as timestamp), "America/New_York")
-        else null
-    end ) as sched_dt
-    ,( case
-        when length(pickuptime) > 0 then datetime(CAST(CONCAT(Substr(pickuptime,0,22)," America/New_York") as timestamp), "America/New_York")
-        else null
-    end ) as pickup_dt
-    ,( case
-        when length(deliveredtime) > 0 then datetime(CAST(CONCAT(Substr(deliveredtime,0,22)," America/New_York") as timestamp), "America/New_York")
-        else null
-    end ) as delivered_dt
-    ,eventid as event_id
-    ,CAST(ismultipart AS BOOL) as is_multipart
-    ,jobtype as job_type
-    ,jobstatus as job_status
-    ,CAST(modifiedby as STRING) as modified_by
-    ,(case
-        when length(modifieddate) > 0 then datetime(CAST(CONCAT(Substr(modifieddate,0,22)," America/New_York") as timestamp), "America/New_York")
-        else null
-    end ) as modified_dt
-    ,emailname as email_name
-    ,emailsubject as email_subject
-    ,CAST(iswrapped AS BOOL) as is_wrapped
-    ,testemailaddr as test_email_addr
-    ,category as category
-    ,bccemail as bcc_email
-    ,originalschedtime as original_sched_time
-    ,( case
-        when length(createddate) > 0 then datetime(CAST(CONCAT(Substr(createddate,0,22)," America/New_York") as timestamp), "America/New_York")
-        else null
-    end ) as created_dt
-    ,characterset as character_set
-    ,ipaddress as ip_address
-    ,CAST(salesforcetotalsubscribercount AS INT64) as salesforce_total_subscriber_count
-    ,CAST(salesforceerrorsubscribercount AS INT64) as salesforce_error_subscriber_count
-    ,sendtype as send_type
-    ,dynamicemailsubject as dynamic_email_subject
-    ,CAST(suppresstracking AS BOOL) as suppress_tracking
-    ,sendclassificationtype as send_classification_type
-    ,sendclassification as send_classification
-    ,CAST(resolvelinkswithcurrentdata AS BOOL) as resolve_links_with_current_data
-    ,emailsenddefinition as email_send_definition
-    ,CAST(deduplicatebyemail AS BOOL) as deduplicated_by_email
-    ,triggerersenddefinitionobjectid as triggerrer_send_definition_object_id
-    ,triggeredsendcustomerkey as triggered_send_customer_key
-    from ({{ dbt_utils.union_relations(relations) }})
+select distinct
+    cast(__jobid_ as int64) as job_id,
+    cast(emailid as int64) as email_id,
+    cast(accountid as int64) as account_id,
+    cast(accountuserid as int64) as account_user_id,
+    fromname as from_name,
+    fromemail as from_email,
+    (
+        case
+            when length(schedtime) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(schedtime, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
+            else null
+        end
+    ) as sched_dt,
+    (
+        case
+            when length(pickuptime) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(pickuptime, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
+            else null
+        end
+    ) as pickup_dt,
+    (
+        case
+            when length(deliveredtime) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(deliveredtime, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
+            else null
+        end
+    ) as delivered_dt,
+    eventid as event_id,
+    cast(ismultipart as bool) as is_multipart,
+    jobtype as job_type,
+    jobstatus as job_status,
+    cast(modifiedby as string) as modified_by,
+    (
+        case
+            when length(modifieddate) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(modifieddate, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
+            else null
+        end
+    ) as modified_dt,
+    emailname as email_name,
+    emailsubject as email_subject,
+    cast(iswrapped as bool) as is_wrapped,
+    testemailaddr as test_email_addr,
+    category as category,
+    bccemail as bcc_email,
+    originalschedtime as original_sched_time,
+    (
+        case
+            when length(createddate) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(createddate, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
+            else null
+        end
+    ) as created_dt,
+    characterset as character_set,
+    ipaddress as ip_address,
+    cast(salesforcetotalsubscribercount as int64) as salesforce_total_subscriber_count,
+    cast(salesforceerrorsubscribercount as int64) as salesforce_error_subscriber_count,
+    sendtype as send_type,
+    dynamicemailsubject as dynamic_email_subject,
+    cast(suppresstracking as bool) as suppress_tracking,
+    sendclassificationtype as send_classification_type,
+    sendclassification as send_classification,
+    cast(resolvelinkswithcurrentdata as bool) as resolve_links_with_current_data,
+    emailsenddefinition as email_send_definition,
+    cast(deduplicatebyemail as bool) as deduplicated_by_email,
+    triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+    triggeredsendcustomerkey as triggered_send_customer_key
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journey.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journey.sql
@@ -1,30 +1,63 @@
 {% macro create_stg_src_stitch_email_journey() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^journey$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^journey$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
-
-Select DISTINCT
-        __versionid_ as version_id
-        ,journeyid as journey_id
-        ,journeyname as journey_name
-        ,CAST(versionnumber AS INT64) as version_number
-        ,( case
-            when length(createddate) > 0 then datetime(CAST(CONCAT(Substr(createddate,0,22)," America/New_York") as timestamp), "America/New_York")
+select distinct
+    __versionid_ as version_id,
+    journeyid as journey_id,
+    journeyname as journey_name,
+    cast(versionnumber as int64) as version_number,
+    (
+        case
+            when length(createddate) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(createddate, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
             else null
-        end ) as created_dt
-        ,( case
-            when length(lastpublisheddate) > 0 then datetime(CAST(CONCAT(Substr(lastpublisheddate,0,22)," America/New_York") as timestamp), "America/New_York")
+        end
+    ) as created_dt,
+    (
+        case
+            when length(lastpublisheddate) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(lastpublisheddate, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
             else null
-        end ) as last_published_dt
-        ,( case
-            when length(modifieddate) > 0 then datetime(CAST(CONCAT(Substr(ModifiedDate,0,22)," America/New_York") as timestamp), "America/New_York")
+        end
+    ) as last_published_dt,
+    (
+        case
+            when length(modifieddate) > 0
+            then
+                datetime(
+                    cast(
+                        concat(
+                            substr(modifieddate, 0, 22), " America/New_York"
+                        ) as timestamp
+                    ),
+                    "America/New_York"
+                )
             else null
-        end ) as modified_dt
-        ,journeystatus as journey_status
+        end
+    ) as modified_dt,
+    journeystatus as journey_status
 
-
-     from ({{ dbt_utils.union_relations(relations) }})
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journeyactivity.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journeyactivity.sql
@@ -1,16 +1,18 @@
 {% macro create_stg_src_stitch_email_journeyactivity() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^journeyactivity$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^journeyactivity$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
-      select distinct
-        __versionid_ as version_id
-        ,activityid as activity_id
-        ,activityname as activity_name
-        ,activityexternalkey as activity_external_key
-        ,journeyactivityobjectid as journey_activity_object_id
-        ,activitytype as activity_type
-         from ({{ dbt_utils.union_relations(relations) }})
+select distinct
+    __versionid_ as version_id,
+    activityid as activity_id,
+    activityname as activity_name,
+    activityexternalkey as activity_external_key,
+    journeyactivityobjectid as journey_activity_object_id,
+    activitytype as activity_type
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
@@ -1,25 +1,28 @@
 {% macro create_stg_src_stitch_email_open() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^open$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^open$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
+select distinct
+    cast(__accountid_ as int64) as account_id,
+    cast(oybaccountid as int64) as oyb_account_id,
+    cast(jobid as int64) as job_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    domain,
+    cast(isunique as bool) as is_unique,
+    triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+    cast(triggeredsendcustomerkey as string) as triggered_send_customer_key
 
-
-select DISTINCT
-        CAST(__accountid_ AS INT64) as account_id
-        ,CAST(oybaccountid AS INT64) as oyb_account_id
-        ,CAST(jobid AS INT64) as job_id
-        ,CAST(listid AS INT64) as list_id
-        ,CAST(batchid AS INT64) as batch_id
-        ,CAST(subscriberid AS INT64) as subscriber_id
-        ,subscriberkey as subscriber_key
-        ,datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt
-        , domain
-        ,CAST(isunique AS BOOL) as is_unique
-        ,triggerersenddefinitionobjectid as triggerrer_send_definition_object_id
-        ,CAST(triggeredsendcustomerkey as STRING) as triggered_send_customer_key
-
-    from ({{ dbt_utils.union_relations(relations) }})
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_sent.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_sent.sql
@@ -1,23 +1,27 @@
 {% macro create_stg_src_stitch_email_sent() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^sent$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^sent$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
+select distinct
+    cast(__accountid_ as int64) as account_id,
+    cast(oybaccountid as int64) as oyb_account_id,
+    cast(jobid as int64) as message_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    domain,
+    triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+    triggeredsendcustomerkey as triggered_send_customer_key
 
-SELECT distinct
-        CAST(__accountid_ AS INT64) as account_id
-        ,CAST(oybaccountid AS INT64) as oyb_account_id
-        ,CAST(jobid AS INT64) as message_id
-        ,CAST(listid AS INT64) as list_id
-        ,CAST(batchid AS INT64) as batch_id
-        ,CAST(subscriberid AS INT64) as subscriber_id
-        ,subscriberkey as subscriber_key
-        ,datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt
-        ,domain
-        ,triggerersenddefinitionobjectid as triggerrer_send_definition_object_id
-        ,TriggeredSendCustomerKey as triggered_send_customer_key
-
-    from ({{ dbt_utils.union_relations(relations) }})
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_unsubscribe.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_unsubscribe.sql
@@ -1,21 +1,25 @@
 {% macro create_stg_src_stitch_email_unsubscribe() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^unsubscribe$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^unsubscribe$",
     is_source=True,
-  source_name='stitch_sfmc_email',
-  schema_to_search='src_stitch_sfmc_authorized') %}
+    source_name="stitch_sfmc_email",
+    schema_to_search="src_stitch_sfmc_authorized",
+) %}
 
-
-Select DISTINCT
-        CAST(accountid AS INT64) as account_id
-        ,CAST(__oybaccountid_ AS INT64) as oyb_account_id
-        ,CAST(jobid AS INT64) as job_id
-        ,CAST(listid AS INT64) as list_id
-        ,CAST(batchid AS INT64) as batch_id
-        ,CAST(subscriberid AS INT64) as subscriber_id
-        ,subscriberkey as subscriber_key
-        ,datetime(CAST(CONCAT(Substr(eventdate,0,22)," America/New_York") as timestamp), "America/New_York") as event_dt
-        ,CAST(isunique AS BOOL) as is_unique
-        ,domain
-    from ({{ dbt_utils.union_relations(relations) }})
+select distinct
+    cast(accountid as int64) as account_id,
+    cast(__oybaccountid_ as int64) as oyb_account_id,
+    cast(jobid as int64) as job_id,
+    cast(listid as int64) as list_id,
+    cast(batchid as int64) as batch_id,
+    cast(subscriberid as int64) as subscriber_id,
+    subscriberkey as subscriber_key,
+    datetime(
+        cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+        "America/New_York"
+    ) as event_dt,
+    cast(isunique as bool) as is_unique,
+    domain
+from ({{ dbt_utils.union_relations(relations) }})
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_actions_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_actions_rollup.sql
@@ -1,7 +1,7 @@
 {% macro create_stg_stitch_sfmc_email_actions_rollup(
-    reference_name='stg_src_stitch_email_action') %}
-Select  distinct SAFE_CAST(job_id AS string) as message_id,
-null as actions
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_src_stitch_email_action"
+) %}
+select distinct safe_cast(job_id as string) as message_id, null as actions
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_bounces_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_bounces_rollup.sql
@@ -1,14 +1,18 @@
 {% macro create_stg_stitch_sfmc_email_bounces_rollup(
-    reference_name='stg_src_stitch_email_bounce') %}
-SELECT
-SAFE_CAST(job_id AS string) as message_id,
-SUM(CASE WHEN bounce_category_id = '1' THEN 1 ELSE 0 END) AS hard_bounce,
-SUM(CASE WHEN bounce_category_id = '2' THEN 1 ELSE 0 END) AS soft_bounce,
-SUM(CASE WHEN bounce_category_id = '3' THEN 1 ELSE 0 END) AS block_bounce,
-SUM(CASE WHEN bounce_category_id = '5' THEN 1 ELSE 0 END) AS tech_bounce,
-SUM(CASE WHEN bounce_category_id = '4' THEN 1 ELSE 0 END) AS unknown_bounce,
-SUM(CASE WHEN bounce_category_id = '1' THEN 1
-WHEN bounce_category_id = '2' THEN 1 END) as total_bounces
-FROM {{ ref(reference_name) }}
-GROUP BY 1
+    reference_name="stg_src_stitch_email_bounce"
+) %}
+select
+    safe_cast(job_id as string) as message_id,
+    sum(case when bounce_category_id = '1' then 1 else 0 end) as hard_bounce,
+    sum(case when bounce_category_id = '2' then 1 else 0 end) as soft_bounce,
+    sum(case when bounce_category_id = '3' then 1 else 0 end) as block_bounce,
+    sum(case when bounce_category_id = '5' then 1 else 0 end) as tech_bounce,
+    sum(case when bounce_category_id = '4' then 1 else 0 end) as unknown_bounce,
+    sum(
+        case
+            when bounce_category_id = '1' then 1 when bounce_category_id = '2' then 1
+        end
+    ) as total_bounces
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_clicks_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_clicks_rollup.sql
@@ -1,7 +1,7 @@
 {% macro create_stg_stitch_sfmc_email_clicks_rollup(
-    reference_name='stg_src_stitch_email_click') %}
-Select SAFE_CAST(job_id AS string) as message_id,
-        SAFE_CAST(count(*) as INT) as clicks
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_src_stitch_email_click"
+) %}
+select safe_cast(job_id as string) as message_id, safe_cast(count(*) as int) as clicks
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_complaints_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_complaints_rollup.sql
@@ -1,7 +1,8 @@
 {% macro create_stg_stitch_sfmc_email_complaints_rollup(
-    reference_name='stg_src_stitch_email_complaint') %}
-SELECT SAFE_CAST(job_id AS STRING) AS message_id,
-  SAFE_CAST(count(*) as INT) as complaints
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_src_stitch_email_complaint"
+) %}
+select
+    safe_cast(job_id as string) as message_id, safe_cast(count(*) as int) as complaints
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_jobs.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_jobs.sql
@@ -1,17 +1,16 @@
-{% macro create_stg_stitch_sfmc_email_job(
-    reference_name='stg_src_stitch_email_job') %}
-SELECT 
-   DISTINCT SAFE_CAST(job_id AS STRING) AS message_id,
-    SAFE_CAST(email_id as STRING) AS email_id,
-    SAFE_CAST(from_name AS STRING) AS from_name,
-    SAFE_CAST(from_email AS STRING) AS from_email,
-    SAFE_CAST(coalesce(sched_dt,pickup_dt) AS TIMESTAMP) AS best_guess_timestamp,
-    SAFE_CAST(sched_dt AS TIMESTAMP) AS scheduled_timestamp,
-    SAFE_CAST(pickup_dt AS TIMESTAMP) AS pickup_timestamp,
-    SAFE_CAST(delivered_dt AS TIMESTAMP) AS delivered_timestamp,
-    SAFE_CAST(email_name AS STRING) AS email_name,
-    SAFE_CAST(email_subject AS STRING) AS email_subject,
-    SAFE_CAST(category as STRING) AS category,
-    SAFE_CAST(NULL AS STRING) AS source_code
-FROM {{ ref(reference_name) }}
+{% macro create_stg_stitch_sfmc_email_job(reference_name="stg_src_stitch_email_job") %}
+select distinct
+    safe_cast(job_id as string) as message_id,
+    safe_cast(email_id as string) as email_id,
+    safe_cast(from_name as string) as from_name,
+    safe_cast(from_email as string) as from_email,
+    safe_cast(coalesce(sched_dt, pickup_dt) as timestamp) as best_guess_timestamp,
+    safe_cast(sched_dt as timestamp) as scheduled_timestamp,
+    safe_cast(pickup_dt as timestamp) as pickup_timestamp,
+    safe_cast(delivered_dt as timestamp) as delivered_timestamp,
+    safe_cast(email_name as string) as email_name,
+    safe_cast(email_subject as string) as email_subject,
+    safe_cast(category as string) as category,
+    safe_cast(null as string) as source_code
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_opens_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_opens_rollup.sql
@@ -1,7 +1,7 @@
 {% macro create_stg_stitch_sfmc_email_opens_rollup(
-    reference_name='stg_src_stitch_email_open') %}
-SELECT SAFE_CAST(job_id AS STRING) AS message_id,
-  SAFE_CAST(count(*) as INT) AS opens
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_src_stitch_email_open"
+) %}
+select safe_cast(job_id as string) as message_id, safe_cast(count(*) as int) as opens
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_recipients_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_recipients_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_stitch_sfmc_email_recipients_rollup(
-    reference_name='stg_src_stitch_email_sent') %}
-SELECT SAFE_CAST(message_id AS STRING) AS message_id,
-  COUNT(SAFE_CAST(subscriber_id AS INT)) AS recipients
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_src_stitch_email_sent"
+) %}
+select
+    safe_cast(message_id as string) as message_id,
+    count(safe_cast(subscriber_id as int)) as recipients
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_unsubscribes_rollup.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_unsubscribes_rollup.sql
@@ -1,7 +1,9 @@
 {% macro create_stg_stitch_sfmc_email_unsubscribes_rollup(
-    reference_name='stg_src_stitch_email_unsubscribe') %}
- SELECT SAFE_CAST(job_id AS STRING) AS message_id,
- SAFE_CAST(count(*) AS INT) as unsubscribes
-FROM {{ ref(reference_name) }} 
-GROUP BY 1
+    reference_name="stg_src_stitch_email_unsubscribe"
+) %}
+select
+    safe_cast(job_id as string) as message_id,
+    safe_cast(count(*) as int) as unsubscribes
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_fundraiseup_transactions/staging/stg_src_stitch_sfmc_fundraiseup_recent_transaction.sql
+++ b/macros/stitch_sfmc_fundraiseup_transactions/staging/stg_src_stitch_sfmc_fundraiseup_recent_transaction.sql
@@ -1,35 +1,42 @@
 {% macro create_stg_src_stitch_sfmc_fundraiseup_recent_transaction() %}
-{% set relations= dbt_arc_functions.relations_that_match_regex('^recent_transactions$',
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^recent_transactions$",
     is_source=True,
-  source_name='src_stitch_fundraiseup',
-  schema_to_search='src_stitch_fundraiseup_authorized') %}
+    source_name="src_stitch_fundraiseup",
+    schema_to_search="src_stitch_fundraiseup_authorized",
+) %}
 
-with fru as (
-    SELECT
-        fru_donation_id as revenue_id
-        ,__initial_market_source_ as initial_market_source
-        ,email_address as email
-        ,amount
-        ,gift_type
-        ,SAFE_CAST(transaction_date AS DATETIME) as transaction_date
-        ,appeal
-        ,designation
-        ,SAFE_CAST(SUBSTR(sfmc_updatedate,1,19) AS DATETIME) as sfmc_insert_dt
-        ,SAFE_CAST(migrated AS BOOL) migrated
-        ,bbcrmlookupid as lookup_id
-        ,SAFE_CAST(SUBSTR(sfmc_updatedate,1,19) AS DATETIME) as sfmc_updated_dt
-        ,_sdc_received_at
+with
+    fru as (
+        select
+            fru_donation_id as revenue_id,
+            __initial_market_source_ as initial_market_source,
+            email_address as email,
+            amount,
+            gift_type,
+            safe_cast(transaction_date as datetime) as transaction_date,
+            appeal,
+            designation,
+            safe_cast(substr(sfmc_updatedate, 1, 19) as datetime) as sfmc_insert_dt,
+            safe_cast(migrated as bool) migrated,
+            bbcrmlookupid as lookup_id,
+            safe_cast(substr(sfmc_updatedate, 1, 19) as datetime) as sfmc_updated_dt,
+            _sdc_received_at
 
-    from  {{ dbt_utils.union_relations(relations) }}
+        from {{ dbt_utils.union_relations(relations) }}
 
-), fru_ranked as (
+    ),
+    fru_ranked as (
 
-    SELECT *
-    ,row_number() OVER (Partition by revenue_id order by transaction_date desc, _sdc_received_at desc nulls last) as row_num
-    FROM fru
-)
-Select
-* Except(row_num, _sdc_received_at)
-from fru_ranked WHERE row_num = 1
-AND CAST(amount AS FLOAT64) < 9999
+        select
+            *,
+            row_number() over (
+                partition by revenue_id
+                order by transaction_date desc, _sdc_received_at desc nulls last
+            ) as row_num
+        from fru
+    )
+select * except (row_num, _sdc_received_at)
+from fru_ranked
+where row_num = 1 and cast(amount as float64) < 9999
 {% endmacro %}

--- a/macros/stitch_sfmc_fundraiseup_transactions/staging/stg_stitch_sfmc_fundraiseup_filtered_recent_transaction.sql
+++ b/macros/stitch_sfmc_fundraiseup_transactions/staging/stg_stitch_sfmc_fundraiseup_filtered_recent_transaction.sql
@@ -1,26 +1,21 @@
 {% macro create_stg_stitch_sfmc_fundraiseup_recent_transaction(
-    reference_name = 'stg_src_stitch_sfmc_fundraiseup_recent_transaction',
-    reference_name1 = 'stg_stitch_sfmc_bbcrm_transaction'
+    reference_name="stg_src_stitch_sfmc_fundraiseup_recent_transaction",
+    reference_name1="stg_stitch_sfmc_bbcrm_transaction"
 ) %}
-with bbcrm as(
-SELECT *
-FROM {{ref(reference_name1)}}
-)
-    Select
-        revenue_id as transaction_id,
-        lookup_id as person_id,
-        initial_market_source as source_code,
-        SAFE_CAST('sfmc_fundraiseup' as STRING) as crm,
-        SAFE_CAST(REGEXP_EXTRACT(initial_market_source,r"sfmc(\d{6})") AS INT) as message_id,
-        transaction_date,
-        amount,
-        gift_type,
-        appeal
-        from {{ref(reference_name)}}
-        where transaction_date > (SELECT MAX(transaction_date) FROM bbcrm)
+with bbcrm as (select * from {{ ref(reference_name1) }})
+select
+    revenue_id as transaction_id,
+    lookup_id as person_id,
+    initial_market_source as source_code,
+    safe_cast('sfmc_fundraiseup' as string) as crm,
+    safe_cast(
+        regexp_extract(initial_market_source, r"sfmc(\d{6})") as int
+    ) as message_id,
+    transaction_date,
+    amount,
+    gift_type,
+    appeal
+from {{ ref(reference_name) }}
+where transaction_date > (select max(transaction_date) from bbcrm)
 
-
-
-
-
-    {% endmacro %}
+{% endmacro %}

--- a/macros/stitch_sfmc_transactions/staging/stg_stitch_sfmc_transactions_unioned.sql
+++ b/macros/stitch_sfmc_transactions/staging/stg_stitch_sfmc_transactions_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_stitch_sfmc_transactions_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_stitch_.*_transaction$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_stitch_.*_transaction$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaign_dates.sql
+++ b/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaign_dates.sql
@@ -1,32 +1,70 @@
 {% macro create_stg_stitch_sfmc_uusa_email_campaign_dates(
-    reference_name='stg_src_stitch_email_job') %}
-SELECT
-  SAFE_CAST(coalesce( sched_dt,pickup_dt) as TIMESTAMP) as campaign_timestamp,
-  SAFE_CAST(null AS STRING) AS crm_campaign,
-  SAFE_CAST(
-    (case
-        when lower(email_name) like '%postcard%' then 'Postcard'
-        when lower(email_name) like '%newswire%' then 'Newswire'
-        when regexp_contains(left(email_name, 1), r'^[0-9]$') then regexp_extract(email_name,r"([a-zA-Z]+)")
-        when lower(email_name) like '%ukraine%donor%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)ukraine donors.*'))
-        when (lower(email_name) like '%mass%' or lower(email_name) like '%active%')
-          then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)mass.*'))
-        when lower(email_name) like '%midlevel%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)midlevel.*'))
-        when lower(email_name) like '%leadership%giving%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)leadership giving.*'))
-        when lower(email_name) like '%monthly%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)monthly.*'))
-        when lower(email_name) like '%major%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)major.*'))
-        when lower(email_name) like '%unite%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)unite.*'))
-        when lower(email_name) like '%clubs%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)clubs.*'))
-        when (lower(email_name) like 'niche%' and lower(email_name) like '%series%') then 'Niche WS'
-        when (lower(email_name) like 'advocacy%' and lower(email_name) like '%series%') then 'Advocacy WS'
-        when lower(email_name) like 'new%name%' then 'New Name WS'
-        when lower(email_name) like 'new%donor%'  then 'New Donor WS'
-        when lower(email_name) like '%quiz%series%' then 'Quiz WS'
-        when lower(email_name) like '%monthly%nurture%' then 'Monthly Nurture Series'
-        when lower(email_name) like '%reactivation%' then 'Reactivation Series'
-        when lower(email_name) like '%upsell%' then 'Upsell Series'
-        when lower(email_name) not like '%series%' then regexp_extract(email_name,r"([a-zA-Z]+)")
-        end) AS STRING) AS source_code_campaign
-FROM {{ ref(reference_name) }}
+    reference_name="stg_src_stitch_email_job"
+) %}
+select
+    safe_cast(coalesce(sched_dt, pickup_dt) as timestamp) as campaign_timestamp,
+    safe_cast(null as string) as crm_campaign,
+    safe_cast(
+        (
+            case
+                when lower(email_name) like '%postcard%'
+                then 'Postcard'
+                when lower(email_name) like '%newswire%'
+                then 'Newswire'
+                when regexp_contains(left(email_name, 1), r'^[0-9]$')
+                then regexp_extract(email_name, r"([a-zA-Z]+)")
+                when lower(email_name) like '%ukraine%donor%'
+                then
+                    initcap(regexp_extract(lower(email_name), r'(.*?)ukraine donors.*'))
+                when
+                    (
+                        lower(email_name) like '%mass%'
+                        or lower(email_name) like '%active%'
+                    )
+                then initcap(regexp_extract(lower(email_name), r'(.*?)mass.*'))
+                when lower(email_name) like '%midlevel%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)midlevel.*'))
+                when lower(email_name) like '%leadership%giving%'
+                then
+                    initcap(
+                        regexp_extract(lower(email_name), r'(.*?)leadership giving.*')
+                    )
+                when lower(email_name) like '%monthly%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)monthly.*'))
+                when lower(email_name) like '%major%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)major.*'))
+                when lower(email_name) like '%unite%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)unite.*'))
+                when lower(email_name) like '%clubs%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)clubs.*'))
+                when
+                    (
+                        lower(email_name) like 'niche%'
+                        and lower(email_name) like '%series%'
+                    )
+                then 'Niche WS'
+                when
+                    (
+                        lower(email_name) like 'advocacy%'
+                        and lower(email_name) like '%series%'
+                    )
+                then 'Advocacy WS'
+                when lower(email_name) like 'new%name%'
+                then 'New Name WS'
+                when lower(email_name) like 'new%donor%'
+                then 'New Donor WS'
+                when lower(email_name) like '%quiz%series%'
+                then 'Quiz WS'
+                when lower(email_name) like '%monthly%nurture%'
+                then 'Monthly Nurture Series'
+                when lower(email_name) like '%reactivation%'
+                then 'Reactivation Series'
+                when lower(email_name) like '%upsell%'
+                then 'Upsell Series'
+                when lower(email_name) not like '%series%'
+                then regexp_extract(email_name, r"([a-zA-Z]+)")
+            end
+        ) as string
+    ) as source_code_campaign
+from {{ ref(reference_name) }}
 {% endmacro %}
-

--- a/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaign_dates_rollup.sql
+++ b/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaign_dates_rollup.sql
@@ -1,9 +1,10 @@
 {% macro create_stg_stitch_sfmc_uusa_email_campaign_dates_rollup(
-    reference_name='stg_stitch_sfmc_uusa_email_campaign_dates') %}
-SELECT 
-  COALESCE(crm_campaign,source_code_campaign) AS campaign_name,
-  MIN(campaign_timestamp) as campaign_start_timestamp,
-  MAX(campaign_timestamp) as campaign_latest_timestamp
-FROM {{ ref(reference_name) }}
-GROUP BY 1
+    reference_name="stg_stitch_sfmc_uusa_email_campaign_dates"
+) %}
+select
+    coalesce(crm_campaign, source_code_campaign) as campaign_name,
+    min(campaign_timestamp) as campaign_start_timestamp,
+    max(campaign_timestamp) as campaign_latest_timestamp
+from {{ ref(reference_name) }}
+group by 1
 {% endmacro %}

--- a/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaigns.sql
+++ b/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaigns.sql
@@ -1,50 +1,109 @@
 {% macro create_stg_stitch_sfmc_uusa_email_campaigns(
-    reference_name='stg_src_stitch_email_job') %}
+    reference_name="stg_src_stitch_email_job"
+) %}
 
-SELECT DISTINCT
-  SAFE_CAST(job_id AS STRING) AS message_id,
-  SAFE_CAST('sfmc' as STRING) as crm_entity,
-  SAFE_CAST(null as STRING) as source_code_entity,
-  SAFE_CAST((case
-           when (lower(email_name) like '%active%' and lower(email_name) not like '%inactive%') or lower(email_name) like '%mass%' then 'Mass'
-           when lower(email_name) like '%inactive%' then 'Inactive'
-           when lower(email_name) like '%mid%level%' or lower(email_name) like '%leadership%giving%' then 'Leadership Giving'
-           when lower(email_name) like '%monthly%' then 'Monthly'
-           when lower(email_name) like '% other %' then 'Other - Targeted'
-           when lower(email_name) like '%welcome%' then 'Welcome Series'
-           when lower(email_name) like '%ramp%' then 'IP Ramp'
-           when lower(email_name) like '%lapse%' then 'Lapsed'
-           when lower(email_name) like '%major%donor%' then 'Major Donors'
-           else 'Other'
-           end) as STRING) as audience,
-  SAFE_CAST(null as STRING) as recurtype,
-  SAFE_CAST(null as STRING) as campaign_category,
-  SAFE_CAST(null AS STRING) AS crm_campaign,
-  SAFE_CAST(
-    (case
-        when lower(email_name) like '%postcard%' then 'Postcard'
-        when lower(email_name) like '%newswire%' then 'Newswire'
-        when regexp_contains(left(email_name, 1), r'^[0-9]$') then regexp_extract(email_name,r"([a-zA-Z]+)")
-        when lower(email_name) like '%ukraine%donor%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)ukraine donors.*'))
-        when (lower(email_name) like '%mass%' or lower(email_name) like '%active%')
-          then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)mass.*'))
-        when lower(email_name) like '%midlevel%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)midlevel.*'))
-        when lower(email_name) like '%leadership%giving%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)leadership giving.*'))
-        when lower(email_name) like '%monthly%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)monthly.*'))
-        when lower(email_name) like '%major%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)major.*'))
-        when lower(email_name) like '%unite%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)unite.*'))
-        when lower(email_name) like '%clubs%' then INITCAP(REGEXP_EXTRACT(lower(email_name), r'(.*?)clubs.*'))
-        when (lower(email_name) like 'niche%' and lower(email_name) like '%series%') then 'Niche WS'
-        when (lower(email_name) like 'advocacy%' and lower(email_name) like '%series%') then 'Advocacy WS'
-        when lower(email_name) like 'new%name%' then 'New Name WS'
-        when lower(email_name) like 'new%donor%'  then 'New Donor WS'
-        when lower(email_name) like '%quiz%series%' then 'Quiz WS'
-        when lower(email_name) like '%monthly%nurture%' then 'Monthly Nurture Series'
-        when lower(email_name) like '%reactivation%' then 'Reactivation Series'
-        when lower(email_name) like '%upsell%' then 'Upsell Series'
-        when lower(email_name) not like '%series%' then regexp_extract(email_name,r"([a-zA-Z]+)")
-        end) AS STRING) AS source_code_campaign
+select distinct
+    safe_cast(job_id as string) as message_id,
+    safe_cast('sfmc' as string) as crm_entity,
+    safe_cast(null as string) as source_code_entity,
+    safe_cast(
+        (
+            case
+                when
+                    (
+                        lower(email_name) like '%active%'
+                        and lower(email_name) not like '%inactive%'
+                    )
+                    or lower(email_name) like '%mass%'
+                then 'Mass'
+                when lower(email_name) like '%inactive%'
+                then 'Inactive'
+                when
+                    lower(email_name) like '%mid%level%'
+                    or lower(email_name) like '%leadership%giving%'
+                then 'Leadership Giving'
+                when lower(email_name) like '%monthly%'
+                then 'Monthly'
+                when lower(email_name) like '% other %'
+                then 'Other - Targeted'
+                when lower(email_name) like '%welcome%'
+                then 'Welcome Series'
+                when lower(email_name) like '%ramp%'
+                then 'IP Ramp'
+                when lower(email_name) like '%lapse%'
+                then 'Lapsed'
+                when lower(email_name) like '%major%donor%'
+                then 'Major Donors'
+                else 'Other'
+            end
+        ) as string
+    ) as audience,
+    safe_cast(null as string) as recurtype,
+    safe_cast(null as string) as campaign_category,
+    safe_cast(null as string) as crm_campaign,
+    safe_cast(
+        (
+            case
+                when lower(email_name) like '%postcard%'
+                then 'Postcard'
+                when lower(email_name) like '%newswire%'
+                then 'Newswire'
+                when regexp_contains(left(email_name, 1), r'^[0-9]$')
+                then regexp_extract(email_name, r"([a-zA-Z]+)")
+                when lower(email_name) like '%ukraine%donor%'
+                then
+                    initcap(regexp_extract(lower(email_name), r'(.*?)ukraine donors.*'))
+                when
+                    (
+                        lower(email_name) like '%mass%'
+                        or lower(email_name) like '%active%'
+                    )
+                then initcap(regexp_extract(lower(email_name), r'(.*?)mass.*'))
+                when lower(email_name) like '%midlevel%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)midlevel.*'))
+                when lower(email_name) like '%leadership%giving%'
+                then
+                    initcap(
+                        regexp_extract(lower(email_name), r'(.*?)leadership giving.*')
+                    )
+                when lower(email_name) like '%monthly%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)monthly.*'))
+                when lower(email_name) like '%major%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)major.*'))
+                when lower(email_name) like '%unite%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)unite.*'))
+                when lower(email_name) like '%clubs%'
+                then initcap(regexp_extract(lower(email_name), r'(.*?)clubs.*'))
+                when
+                    (
+                        lower(email_name) like 'niche%'
+                        and lower(email_name) like '%series%'
+                    )
+                then 'Niche WS'
+                when
+                    (
+                        lower(email_name) like 'advocacy%'
+                        and lower(email_name) like '%series%'
+                    )
+                then 'Advocacy WS'
+                when lower(email_name) like 'new%name%'
+                then 'New Name WS'
+                when lower(email_name) like 'new%donor%'
+                then 'New Donor WS'
+                when lower(email_name) like '%quiz%series%'
+                then 'Quiz WS'
+                when lower(email_name) like '%monthly%nurture%'
+                then 'Monthly Nurture Series'
+                when lower(email_name) like '%reactivation%'
+                then 'Reactivation Series'
+                when lower(email_name) like '%upsell%'
+                then 'Upsell Series'
+                when lower(email_name) not like '%series%'
+                then regexp_extract(email_name, r"([a-zA-Z]+)")
+            end
+        ) as string
+    ) as source_code_campaign
 
-FROM {{ ref(reference_name) }}
+from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaigns_rollup.sql
+++ b/macros/stitch_sfmc_uusa_email/staging/stg_stitch_sfmc_uusa_email_campaigns_rollup.sql
@@ -1,11 +1,14 @@
-null{% macro create_stg_stitch_sfmc_uusa_email_campaigns_rollup(
-    reference_name='stg_stitch_sfmc_uusa_email_campaigns') %}
-SELECT DISTINCT message_id,
+null
+{% macro create_stg_stitch_sfmc_uusa_email_campaigns_rollup(
+    reference_name="stg_stitch_sfmc_uusa_email_campaigns"
+) %}
+select distinct
+    message_id,
     crm_entity,
     source_code_entity,
     audience,
     recurtype,
     campaign_category,
-    COALESCE(crm_campaign,source_code_campaign) AS campaign_name
-FROM {{ ref(reference_name) }}
+    coalesce(crm_campaign, source_code_campaign) as campaign_name
+from {{ ref(reference_name) }}
 {% endmacro %}

--- a/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_campaigns.sql
+++ b/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_campaigns.sql
@@ -1,11 +1,12 @@
 {% macro create_stg_supermetrics_yahoo_dsp_paidmedia_campaigns(
-       source_name='supermetrics_yahoo_dsp_paidmedia',
-       source_table_name='alldates_VDSP_AD') 
-%}
-SELECT  DISTINCT SAFE_CAST(ad.line_id AS STRING)     AS campaign_id
-       ,SAFE_CAST(ad.ad_id AS STRING)                AS message_id
-       ,SAFE_CAST('yahoo_dsp' AS STRING)             AS channel
-       ,SAFE_CAST(NULL AS STRING)                    AS channel_type
-       ,SAFE_CAST(ad.line_name AS STRING)            AS campaign_name
-FROM {{ source(source_name,source_table_name) }} ad
+    source_name="supermetrics_yahoo_dsp_paidmedia",
+    source_table_name="alldates_VDSP_AD"
+) %}
+select distinct
+    safe_cast(ad.line_id as string) as campaign_id,
+    safe_cast(ad.ad_id as string) as message_id,
+    safe_cast('yahoo_dsp' as string) as channel,
+    safe_cast(null as string) as channel_type,
+    safe_cast(ad.line_name as string) as campaign_name
+from {{ source(source_name, source_table_name) }} ad
 {% endmacro %}

--- a/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_clicks_daily_rollup.sql
+++ b/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_clicks_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_supermetrics_yahoo_dsp_paidmedia_clicks_daily_roundup(
-       source_name='supermetrics_yahoo_dsp_paidmedia',
-       source_table_name='alldates_VDSP_AD') 
-%}
-SELECT  DISTINCT SAFE_CAST(ad_id AS STRING)             AS message_id
-       ,SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp
-       ,SAFE_CAST(ad_summary_by_date.clicks AS INT)     AS total_clicks
-       ,SAFE_CAST(ad_summary_by_date.clicks AS INT)     AS unique_clicks 
-FROM {{ source(source_name,source_table_name) }} ad_summary_by_date
+    source_name="supermetrics_yahoo_dsp_paidmedia",
+    source_table_name="alldates_VDSP_AD"
+) %}
+select distinct
+    safe_cast(ad_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary_by_date.clicks as int) as total_clicks,
+    safe_cast(ad_summary_by_date.clicks as int) as unique_clicks
+from {{ source(source_name, source_table_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_impressions_daily_rollup.sql
+++ b/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_impressions_daily_rollup.sql
@@ -1,10 +1,11 @@
 {% macro create_stg_supermetrics_yahoo_dsp_paidmedia_impressions_daily_roundup(
-       source_name='supermetrics_yahoo_dsp_paidmedia',
-       source_table_name='alldates_VDSP_AD') 
-%}
-SELECT  DISTINCT SAFE_CAST(ad_summary_by_date.ad_id AS STRING) AS message_id
-       ,SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP)        AS date_timestamp
-       ,SAFE_CAST(ad_summary_by_date.impressions AS INT)       AS total_impressions
-       ,SAFE_CAST(ad_summary_by_date.impressions AS INT)       AS unique_impressions
-FROM {{ source(source_name,source_table_name) }} ad_summary_by_date
+    source_name="supermetrics_yahoo_dsp_paidmedia",
+    source_table_name="alldates_VDSP_AD"
+) %}
+select distinct
+    safe_cast(ad_summary_by_date.ad_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary_by_date.impressions as int) as total_impressions,
+    safe_cast(ad_summary_by_date.impressions as int) as unique_impressions
+from {{ source(source_name, source_table_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_spends_daily_rollup.sql
+++ b/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_spends_daily_rollup.sql
@@ -1,9 +1,10 @@
 {% macro create_stg_supermetrics_yahoo_dsp_paidmedia_spends_daily_roundup(
-       source_name='supermetrics_yahoo_dsp_paidmedia',
-       source_table_name='alldates_VDSP_AD') 
-%}
-SELECT  DISTINCT SAFE_CAST(ad_summary_by_date.ad_id AS STRING) AS message_id
-       ,SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP)        AS date_timestamp
-       ,SAFE_CAST(ad_summary_by_date.cost AS NUMERIC)          AS spend_amount
-FROM  {{ source(source_name,source_table_name) }} ad_summary_by_date
+    source_name="supermetrics_yahoo_dsp_paidmedia",
+    source_table_name="alldates_VDSP_AD"
+) %}
+select distinct
+    safe_cast(ad_summary_by_date.ad_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(ad_summary_by_date.cost as numeric) as spend_amount
+from {{ source(source_name, source_table_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_subscribes_daily_rollup.sql
+++ b/macros/supermetrics_yahoo_dsp_paidmedia/staging/stg_supermetrics_yahoo_dsp_paidmedia_subscribes_daily_rollup.sql
@@ -1,8 +1,10 @@
 {% macro create_stg_supermetrics_yahoo_dsp_paidmedia_subscribes_daily_rollup(
-       source_name='supermetrics_yahoo_dsp_paidmedia',
-       source_table_name='alldates_VDSP_AD') %}
-SELECT DISTINCT  SAFE_CAST(ad_summary_by_date.ad_id AS STRING) AS message_id,
-  SAFE_CAST(ad_summary_by_date.date AS TIMESTAMP) AS date_timestamp,
-  SAFE_CAST(NULL AS INTEGER) AS subscribes
-FROM   {{ source(source_name,source_table_name) }}  ad_summary_by_date
+    source_name="supermetrics_yahoo_dsp_paidmedia",
+    source_table_name="alldates_VDSP_AD"
+) %}
+select distinct
+    safe_cast(ad_summary_by_date.ad_id as string) as message_id,
+    safe_cast(ad_summary_by_date.date as timestamp) as date_timestamp,
+    safe_cast(null as integer) as subscribes
+from {{ source(source_name, source_table_name) }} ad_summary_by_date
 {% endmacro %}

--- a/macros/transactions/marts/mart_transactions_daily_rollup.sql
+++ b/macros/transactions/marts/mart_transactions_daily_rollup.sql
@@ -1,49 +1,29 @@
 {% macro create_mart_transactions_daily_rollup(
-    reference_name='stg_transactions_unioned') %}
-SELECT
-  best_guess_message_id,
-  EXTRACT(DATE
-  FROM
-    transaction_timestamp) AS date_timestamp,
-  transaction_source_code,
-  channel AS channel_from_crm,
-  channel_from_source_code,
-  COALESCE(channel, channel_from_source_code) AS channel_best_guess,
-  campaign,
-  audience,
-  crm_entity,
-  source_code_entity,
-  case when (crm_entity is not null and source_code_entity is not null)
-          then CONCAT(crm_entity,'-', source_code_entity)
-          else COALESCE(crm_entity,source_code_entity) END
-          as best_guess_entity,
-  SUM(amount) AS total_amount,
-  SUM(CASE
-      WHEN recurring_revenue THEN amount
-    ELSE
-    0
-  END
-    ) as total_recurring_revenue,
-  SUM(CASE
-      WHEN new_recurring_revenue THEN amount
-    ELSE
-    0
-  END
+    reference_name="stg_transactions_unioned"
+) %}
+select
+    best_guess_message_id,
+    extract(date from transaction_timestamp) as date_timestamp,
+    transaction_source_code,
+    channel as channel_from_crm,
+    channel_from_source_code,
+    coalesce(channel, channel_from_source_code) as channel_best_guess,
+    campaign,
+    audience,
+    crm_entity,
+    source_code_entity,
+    case
+        when (crm_entity is not null and source_code_entity is not null)
+        then concat(crm_entity, '-', source_code_entity)
+        else coalesce(crm_entity, source_code_entity)
+    end as best_guess_entity,
+    sum(amount) as total_amount,
+    sum(case when recurring_revenue then amount else 0 end) as total_recurring_revenue,
+    sum(
+        case when new_recurring_revenue then amount else 0 end
     ) as total_new_recurring_revenue,
-  COUNT(DISTINCT person_id) AS number_of_donors,
-  COUNT(transaction_id_in_source_crm) AS number_of_transactions
-FROM
-  {{ ref(reference_name) }}
-GROUP BY
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-    10,
-    11
+    count(distinct person_id) as number_of_donors,
+    count(transaction_id_in_source_crm) as number_of_transactions
+from {{ ref(reference_name) }}
+group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
 {% endmacro %}

--- a/macros/transactions/marts/mart_transactions_hourly_rollup.sql
+++ b/macros/transactions/marts/mart_transactions_hourly_rollup.sql
@@ -1,47 +1,29 @@
 {% macro create_mart_transactions_hourly_rollup(
-    reference_name='stg_transactions_unioned') %}
-SELECT
-  best_guess_message_id,
-  DATETIME_TRUNC(transaction_timestamp, HOUR) as hour_timestamp,
-  transaction_source_code,
-  channel AS channel_from_crm,
-  channel_from_source_code,
-  COALESCE(channel, channel_from_source_code) AS channel_best_guess,
-  campaign,
-  audience,
-  crm_entity,
-  source_code_entity,
-  case when (crm_entity is not null and source_code_entity is not null)
-          then CONCAT(crm_entity,'-', source_code_entity)
-          else COALESCE(crm_entity,source_code_entity) END
-          as best_guess_entity,
-  SUM(amount) AS total_amount,
-  SUM(CASE
-      WHEN recurring_revenue THEN amount
-    ELSE
-    0
-  END
-    ) as total_recurring_revenue,
-  SUM(CASE
-      WHEN new_recurring_revenue THEN amount
-    ELSE
-    0
-  END
+    reference_name="stg_transactions_unioned"
+) %}
+select
+    best_guess_message_id,
+    datetime_trunc(transaction_timestamp, hour) as hour_timestamp,
+    transaction_source_code,
+    channel as channel_from_crm,
+    channel_from_source_code,
+    coalesce(channel, channel_from_source_code) as channel_best_guess,
+    campaign,
+    audience,
+    crm_entity,
+    source_code_entity,
+    case
+        when (crm_entity is not null and source_code_entity is not null)
+        then concat(crm_entity, '-', source_code_entity)
+        else coalesce(crm_entity, source_code_entity)
+    end as best_guess_entity,
+    sum(amount) as total_amount,
+    sum(case when recurring_revenue then amount else 0 end) as total_recurring_revenue,
+    sum(
+        case when new_recurring_revenue then amount else 0 end
     ) as total_new_recurring_revenue,
-  COUNT(DISTINCT person_id) AS number_of_donors,
-  COUNT(transaction_id_in_source_crm) AS number_of_transactions
-FROM
-  {{ ref(reference_name) }}
-GROUP BY
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-    10,
-    11
+    count(distinct person_id) as number_of_donors,
+    count(transaction_id_in_source_crm) as number_of_transactions
+from {{ ref(reference_name) }}
+group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
 {% endmacro %}

--- a/macros/transactions/staging/stg_transactions_unioned.sql
+++ b/macros/transactions/staging/stg_transactions_unioned.sql
@@ -1,4 +1,6 @@
 {% macro create_stg_transactions_unioned() %}
-{% set relations = dbt_arc_functions.relations_that_match_regex('^stg_.*_transactions$') %}
+{% set relations = dbt_arc_functions.relations_that_match_regex(
+    "^stg_.*_transactions$"
+) %}
 {{ dbt_utils.union_relations(relations) }}
 {% endmacro %}

--- a/macros/utils/relations_that_match_regex.sql
+++ b/macros/utils/relations_that_match_regex.sql
@@ -1,17 +1,29 @@
-{% macro relations_that_match_regex(regex,is_source=False,source_name='',schema_to_search='staging') %}
-    {% set re = modules.re %}
-    {% set relation_names = [] %}
-    {% set relations = []%}
-    {% set schema_to_search = (target.schema if not is_source else '') + ('_' if schema_to_search|length > 0 and not is_source else '') + schema_to_search %}
-    {% set table_names = dbt_utils.get_query_results_as_dict("SELECT table_name from "+schema_to_search+".INFORMATION_SCHEMA.TABLES").table_name %}
-    {% for table_name in table_names%}
-        {% if re.match(regex,table_name) %}
-            {% do relation_names.append(table_name) %}
-        {% endif %}
-    {% endfor %}
-    {{relation_names}}
-    {% for relation_name in relation_names%}
-        {% do relations.append(ref(relation_name)) if not is_source else relations.append(source(source_name,relation_name))%}
-    {% endfor %}
-    {% do return(relations) %}
+{% macro relations_that_match_regex(
+    regex, is_source=False, source_name="", schema_to_search="staging"
+) %}
+{% set re = modules.re %}
+{% set relation_names = [] %}
+{% set relations = [] %}
+{% set schema_to_search = (
+    (target.schema if not is_source else "")
+    + ("_" if schema_to_search | length > 0 and not is_source else "")
+    + schema_to_search
+) %}
+{% set table_names = dbt_utils.get_query_results_as_dict(
+    "SELECT table_name from "
+    + schema_to_search
+    + ".INFORMATION_SCHEMA.TABLES"
+).table_name %}
+{% for table_name in table_names %}
+{% if re.match(regex, table_name) %}
+{% do relation_names.append(table_name) %}
+{% endif %}
+{% endfor %}
+{{ relation_names }}
+{% for relation_name in relation_names %}
+{% do relations.append(ref(relation_name)) if not is_source else relations.append(
+    source(source_name, relation_name)
+) %}
+{% endfor %}
+{% do return(relations) %}
 {% endmacro %}


### PR DESCRIPTION
JIRA ticket:
https://bluestate.atlassian.net/browse/ARC-1409

Hey, I wanted to add a SQL formatter. sqlfluff didn’t work but this one seems to work just fine. Here’s what a failure looks like:
https://github.com/bsd/dbt-arc-functions/actions/runs/4638748389/jobs/8208862659

Here’s what it looks like when it works:
https://github.com/bsd/dbt-arc-functions/actions/runs/4638768131/jobs/8208899943

All you have to do to make it pass is run:
`sqlfmt .`
in the base directory and it just formats all the files. It’s very opinionated and we don’t really have any choices on how it formats but… in a way that’s kind of nice because it’ll just be the same on all of our computers. =p

Here’s the PR:
https://github.com/bsd/dbt-arc-functions/pull/202