### PR TITLE
ARC-1429-Audience-Cashflow-Mart-add-fields-to-transaction_unioned-so-that-we-can-pull-from-it-for-audience-modeling

### DIFF
--- a/macros/stitch_sfmc_bbcrm_transactions/staging/stg_stitch_sfmc_bbcrm_transaction.sql
+++ b/macros/stitch_sfmc_bbcrm_transactions/staging/stg_stitch_sfmc_bbcrm_transaction.sql
@@ -10,7 +10,6 @@ select
     safe_cast(
         regexp_extract(initial_market_source, r"sfmc(\d{6})") as int
     ) as message_id,
-    initial_market_source,
     inbound_channel,
     transaction_date,
     amount,

--- a/macros/stitch_sfmc_bbcrm_transactions/staging/stg_stitch_sfmc_bbcrm_transaction.sql
+++ b/macros/stitch_sfmc_bbcrm_transactions/staging/stg_stitch_sfmc_bbcrm_transaction.sql
@@ -10,11 +10,18 @@ select
     safe_cast(
         regexp_extract(initial_market_source, r"sfmc(\d{6})") as int
     ) as message_id,
+    initial_market_source,
+    inbound_channel,
     transaction_date,
     amount,
     appeal,
     appeal_business_unit,
-    application
+    application,
+    case
+        when lower(application) = 'recurring gift'
+        then safe_cast(1 as boolean)
+        else safe_cast(0 as boolean)
+    end as recurring
 from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/stitch_sfmc_fundraiseup_transactions/staging/stg_stitch_sfmc_fundraiseup_filtered_recent_transaction.sql
+++ b/macros/stitch_sfmc_fundraiseup_transactions/staging/stg_stitch_sfmc_fundraiseup_filtered_recent_transaction.sql
@@ -14,7 +14,13 @@ select
     transaction_date,
     amount,
     gift_type,
-    appeal
+    appeal,
+    case
+        when lower(gift_type) = 'monthly'
+        then safe_cast(1 as boolean)
+        else safe_cast(0 as boolean)
+    end as recurring
+
 from {{ ref(reference_name) }}
 where transaction_date > (select max(transaction_date) from bbcrm)
 


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [NA] If you've created a macro, make sure it is documented by running the notebook: `process_model_documentation_codegen_output.ipynb` util in this repo

- [X ] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below. Client is Arc-UUSA. branch is testing-arc-1429

- [X] If new macro files were created or updated, re-run `create_or_update_standard_models.py` for the client dbt project, replacing models and dependencies
dbt compile
<img width="1161" alt="Screenshot 2023-04-13 at 1 32 41 PM" src="https://user-images.githubusercontent.com/109629735/231839185-7fc315ac-1ef3-4472-a65d-f5ad94ad88e2.png">

dbt run
<img width="986" alt="Screenshot 2023-04-13 at 1 32 54 PM" src="https://user-images.githubusercontent.com/109629735/231839208-b969dc2c-5b53-4e1a-a566-f9fa1a8f8d30.png">


- [x ] If exists, link bug issue and jira tickets to PR
https://bluestate.atlassian.net/browse/ARC-1429?atlOrigin=eyJpIjoiYzQyNjVkYTBmNDUwNGY2MjliNmExZDQ2ZTk2MmE1MjEiLCJwIjoiaiJ9
