### PR TITLE
Arc 1501 audience tech planning create transaction rollup by day and person id with added dimensions

### DIFF
--- a/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup.yml
+++ b/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup.yml
@@ -1,0 +1,27 @@
+version: 2
+
+models:
+  - name: stg_stitch_sfmc_audience_transactions_enriched_rollup
+    description: "Audience Transactions rolled up by day and person_id"
+    columns:
+      - name: transaction_date_day
+        description: "Date of transaction in Day format"
+
+      - name: person_id
+        description: "Unique ID of the individual"
+
+      - name: inbound_channel
+        description: "Channel of donation"
+
+      - name: recurring
+        description: "If the transaction is part of a recurring donation"
+
+      - name: recurring_gift_size
+        description: " If the transaction is recurring, then this will hold the gift_size in a string"
+
+      - name: amounts
+        description: "the rolled-up sum of all of a person's transactions by day"
+
+      - name: gifts
+        description: "The number of gifts a person gave in a day"
+

--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup.sql
@@ -1,0 +1,19 @@
+{% macro create_stg_stitch_sfmc_audience_transactions_enriched_rollup(
+    reference_name="stg_stitch_sfmc_audience_transactions_enriched"
+) %}
+
+Select
+    transaction_date_day,
+    person_id,
+    inbound_channel,
+    recurring,
+    (Case
+        When recurring Is True Then gift_size_string
+    End) As recurring_gift_size,
+    sum(amount) As amounts,
+    count(*) As gifts
+from {{ ref(reference_name) }}
+Group By 1, 2, 3, 4, 5
+
+
+{% endmacro %}

--- a/utils/create_docs.ipynb
+++ b/utils/create_docs.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,13 +39,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "is_executing": true
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking if dbt installed...\n",
+      "\n",
+      "Checking if you have a profiles.yml in the .dbt folder...\n",
+      "\n",
+      "Installing dbt deps...\n",
+      "\n",
+      "Running dbt compile...\n",
+      "Looping through files in /Users/d/bsd/dbt/arc-uusa-dbt/models/staging/stitch_sfmc_audience_transaction...\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transaction_jobs.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_jobs.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transaction_first_gift.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_first_gift.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transactions_enriched_rollup.sql\n",
+      "Wrote to /Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup.yml!\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_customizable_audience_transaction_jobs_append.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_customizable_audience_transaction_jobs_append.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transaction_jobs_append.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_jobs_append.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transactions_summary_unioned.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_summary_unioned.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transaction_yoy.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_yoy.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transactions_enriched.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transaction_cumulative.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_cumulative.yml already exists, will not overwrite\n",
+      "\n",
+      "Working on: stg_stitch_sfmc_audience_transactions_join.sql\n",
+      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_join.yml already exists, will not overwrite\n",
+      "\n",
+      "Finished!\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
     "\n",
     "print(\"Checking if dbt installed...\\n\")\n",

--- a/utils/create_docs.ipynb
+++ b/utils/create_docs.ipynb
@@ -15,18 +15,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# NOTE: You should have run dbt build at least once in the past against the working folder\n",
-    "WORKING_FOLDER_WITH_DBT_ARC_FUNCTION_MODELS= \"YOUR PATH HERE.\"\n",
-    "DBT_ARC_FUNCTIONS_MACRO_DOCUMENTATION_FOLDER= \"YOUR PATH HERE.\""
+    "WORKING_FOLDER_WITH_DBT_ARC_FUNCTION_MODELS= \"YOUR PATH HERE\"\n",
+    "DBT_ARC_FUNCTIONS_MACRO_DOCUMENTATION_FOLDER= \"YOUR PATH HERE\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,56 +39,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Checking if dbt installed...\n",
-      "\n",
-      "Checking if you have a profiles.yml in the .dbt folder...\n",
-      "\n",
-      "Installing dbt deps...\n",
-      "\n",
-      "Running dbt compile...\n",
-      "Looping through files in /Users/d/bsd/dbt/arc-uusa-dbt/models/staging/stitch_sfmc_audience_transaction...\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transaction_jobs.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_jobs.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transaction_first_gift.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_first_gift.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transactions_enriched_rollup.sql\n",
-      "Wrote to /Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup.yml!\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_customizable_audience_transaction_jobs_append.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_customizable_audience_transaction_jobs_append.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transaction_jobs_append.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_jobs_append.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transactions_summary_unioned.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_summary_unioned.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transaction_yoy.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_yoy.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transactions_enriched.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transaction_cumulative.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_cumulative.yml already exists, will not overwrite\n",
-      "\n",
-      "Working on: stg_stitch_sfmc_audience_transactions_join.sql\n",
-      "/Users/d/bsd/dbt-arc-functions/documentation/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_join.yml already exists, will not overwrite\n",
-      "\n",
-      "Finished!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "print(\"Checking if dbt installed...\\n\")\n",


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Open the pull request as a draft so that you can run tests against the code and inspect the files in the Files view of the Pull Request interface in Github.

- [x] Once you're satisfied, convert the draft into an open Pull Request by clicking "Ready for Review" near the bottom of this page. You should not make any changes to the code except in dire emergency once you've converted from draft, so make sure you're really satisfied.

- [x] Add two of the principal contributors to this PR for review. Currently, the principal contributors are @dmbluestate , @Frydafly , and @ryantimjohn.


- [x] Link Jira tickets (or Github Issues) to PR here. Make sure that the Jira ticket has a good description as to why this PR is necessary and the business problem that this PR is solving. Moreover, if there have been any discussions of this ticket in Slack, make sure they're linked in the Jira ticket:  https://bluestate.atlassian.net/browse/ARC-1501?atlOrigin=eyJpIjoiMzM5YzUyNzQ5ZTBlNGExZDk5MDY4YzM4YWFiM2I1YWYiLCJwIjoiaiJ9

- [x] Make sure this is named using Jira extension so that naming convention is consistent. If it's not, that's okay. Go to the Jira ticket, click into the ticket, then on the right under Details, find Development, then click the Create branch button. Copy the Branch Name from there. Read here [how to rename a branch in Github](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch) to rename this branch. In the future, create branches from Jira.

- [x] Make sure the Macro is documented by running the notebook: `create_docs.ipynb` util in this repo. From there, you'll have to either fill in descriptions by hand OR use our `fill_in_descriptions_using_openai.ipynb` to fill in descriptions using OpenAI's ChatGPT. Always make sure to check over ChatGPT's column descriptions, as they're likely not perfect.

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below.
- [x] ARC-UUSA

- [x] If new macro files were created or updated, re-run `create_or_update_standard_models.py` for the client dbt project, replacing models and dependencies

- [x] check in dbt that client package successfully runs `dbt deps`, `dbt compile`, and `dbt run`; screenshot this page
dbt deps
<img width="997" alt="Screenshot 2023-07-19 at 1 30 17 PM" src="https://github.com/bsd/dbt-arc-functions/assets/109629735/5d2c71c0-bd71-44c4-be79-6cba29bbccce">


dbt compile

<img width="994" alt="Screenshot 2023-07-19 at 1 29 54 PM" src="https://github.com/bsd/dbt-arc-functions/assets/109629735/08e86f0d-9757-4a74-b66f-fabe9050a615">

dbt run
<img width="1013" alt="Screenshot 2023-07-19 at 1 29 10 PM" src="https://github.com/bsd/dbt-arc-functions/assets/109629735/b4c1e0de-dca9-41e2-9610-b088bf325240">





- [x] query the resulting staging model in bigquery (or by previewing mart in dbt cloud, or your IDE); screenshot this
<img width="1010" alt="Screenshot 2023-07-19 at 1 31 23 PM" src="https://github.com/bsd/dbt-arc-functions/assets/109629735/15529cb0-1c62-4ca8-914f-dadaa274242e">




## Formatters

Three different formatters will run when you open a pull request:
- [sqlfmt](http://sqlfmt.com/)
- [yamlfix](https://lyz-code.github.io/yamlfix/)
- [Black(python)](https://pypi.org/project/black/)

If any of them detect syntax problems, they will error. They will automatically open a pull request with the changes you need to make to pass the formatter. Just merge that PR and you should be good to go.

## Linters
We have two in-house linters:

### [check_for_docs_for_every_macro.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_for_docs_for_every_macro.py)
Just makes sure that every macro has a doc associated with it in the documentation folder with the same folder structure, i.e.:

`documentation/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.yml`

is the doc for

`       macros/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.sql`

### [check_docs_correct.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_docs_correct.py)
Runs through a lot of checks on documents to make sure that they are formatted to our standards. This includes checking whether docs and sources:
- have columns
- have tables
- source columns have data_type and description
- have a version number
- docs have a macro associated with them
- docs are not blank

There may be additional checks not documented here. The linter will fail on any error.

The script will document all failures and display them to you with remedies.
