### PR TITLE
PATCH - fix macro name

### DIFF
--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_jobs.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_email_jobs.sql
@@ -1,4 +1,4 @@
-{% macro create_stg_stitch_sfmc_email_job(reference_name="stg_src_stitch_email_job") %}
+{% macro create_stg_stitch_sfmc_email_jobs(reference_name="stg_src_stitch_email_job") %}
     select distinct
         safe_cast(job_id as string) as message_id,
         safe_cast(email_id as string) as email_id,


### PR DESCRIPTION
This PR changes just one letter -- the macro name didn't match the name of the file, so this patch resolves just that.