### PR TITLE
Arc 1590 looker qa email bug very low recipient count

### DIFF
--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup.sql
@@ -1,12 +1,13 @@
 {% macro create_stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup(
-    reference_name='stg_stitch_sfmc_audience_transaction_with_join_date') %}
-SELECT
-    date_trunc(transaction_date_day, MONTH) AS transaction_month_year_date,
-    date_trunc(join_month_year_date, MONTH) AS join_month_year,
-    sum(amount) AS total_revenue,
-    safe_cast(count(DISTINCT person_id) AS integer) AS total_donors
-FROM {{ ref(reference_name) }}
-GROUP BY 1, 2
-ORDER BY 1, 2
+    reference_name="stg_stitch_sfmc_audience_transaction_with_join_date"
+) %}
+    select
+        date_trunc(transaction_date_day, month) as transaction_month_year_date,
+        date_trunc(join_month_year_date, month) as join_month_year,
+        sum(amount) as total_revenue,
+        safe_cast(count(distinct person_id) as integer) as total_donors
+    from {{ ref(reference_name) }}
+    group by 1, 2
+    order by 1, 2
 
 {% endmacro %}

--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup_with_activation.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup_with_activation.sql
@@ -1,28 +1,27 @@
 {% macro create_stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup_with_activation(
-    reference_name='stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup') %}
-SELECT
-    join_month_year,
-    CONCAT(
-        CAST(EXTRACT(YEAR FROM join_month_year) AS string),
-        '-',
-        LPAD(
-            CAST(EXTRACT(MONTH FROM join_month_year) AS string),
-            2, '0'
-        )
-    ) AS join_month_year_str,
-    CONCAT(
-        'Act',
-        LPAD(
-            CAST(
-                DATE_DIFF(
-                    transaction_month_year_date, join_month_year, MONTH
-                ) AS string
-            ),
-            2, '0'
-        )
-    ) AS activation,
-    total_revenue,
-    total_donors,
-FROM {{ ref(reference_name) }}
+    reference_name="stg_stitch_sfmc_audience_transaction_monthly_recurring_rollup"
+) %}
+    select
+        join_month_year,
+        concat(
+            cast(extract(year from join_month_year) as string),
+            '-',
+            lpad(cast(extract(month from join_month_year) as string), 2, '0')
+        ) as join_month_year_str,
+        concat(
+            'Act',
+            lpad(
+                cast(
+                    date_diff(
+                        transaction_month_year_date, join_month_year, month
+                    ) as string
+                ),
+                2,
+                '0'
+            )
+        ) as activation,
+        total_revenue,
+        total_donors,
+    from {{ ref(reference_name) }}
 
 {% endmacro %}

--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_with_join_date.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transaction_with_join_date.sql
@@ -1,17 +1,15 @@
 {% macro create_stg_stitch_sfmc_audience_transaction_with_join_date(
-    reference_0_name='stg_stitch_sfmc_arc_audience_union_transaction_joined',
-    reference_1_name='stg_stitch_sfmc_audience_transaction_first_gift') %}
-SELECT
-    union_transaction.transaction_date_day AS transaction_date_day,
-    union_transaction.person_id AS person_id,
-    first_gift.join_month_year_date AS join_month_year_date,
-    union_transaction.amount AS amount
-FROM
-    {{ ref(reference_0_name) }}
-        AS union_transaction
-INNER JOIN
-    {{ ref(reference_1_name) }} AS first_gift
-    ON union_transaction.person_id = first_gift.person_id
-WHERE
-    union_transaction.recurring = True
+    reference_0_name="stg_stitch_sfmc_arc_audience_union_transaction_joined",
+    reference_1_name="stg_stitch_sfmc_audience_transaction_first_gift"
+) %}
+    select
+        union_transaction.transaction_date_day as transaction_date_day,
+        union_transaction.person_id as person_id,
+        first_gift.join_month_year_date as join_month_year_date,
+        union_transaction.amount as amount
+    from {{ ref(reference_0_name) }} as union_transaction
+    inner join
+        {{ ref(reference_1_name) }} as first_gift
+        on union_transaction.person_id = first_gift.person_id
+    where union_transaction.recurring = true
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
@@ -1,52 +1,23 @@
 {% macro create_stg_src_stitch_email_action() %}
 
-    with
-        deduplicated_data as (
             select
-                cast(__accountid_ as int64) as account_id,
-                cast(oybaccountid as int64) as oyb_account_id,
-                cast(jobid as int64) as job_id,
-                cast(listid as int64) as list_id,
-                cast(batchid as int64) as batch_id,
-                cast(subscriberid as int64) as subscriber_id,
-                subscriberkey as subscriber_key,
-                datetime(
-                    cast(
-                        concat(
-                            substr(eventdate, 0, 22), " America/New_York"
-                        ) as timestamp
-                    ),
-                    "America/New_York"
+                cast('' as int64) as account_id,
+                cast('' as int64) as oyb_account_id,
+                cast('' as int64) as job_id,
+                cast('' as int64) as list_id,
+                cast('' as int64) as batch_id,
+                cast('' as int64) as subscriber_id,
+                '' as subscriber_key,
+                datetime(''
                 ) as event_dt,
-                domain,
-                url,
-                linkname as link_name,
-                linkcontent as link_content,
-                cast(isunique as bool) as is_unique,
-                triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                triggeredsendcustomerkey as triggered_send_customer_key,
-                row_number() over (partition by subscriberkey order by eventdate) as row_num
+                cast('' as string) as domain,
+                cast('' as string) as url,
+                cast('' as string) as link_name,
+                cast('' as string) as link_content,
+                cast('' as bool) as is_unique,
+                cast('' as string) as triggerrer_send_definition_object_id,
+                cast('' as string) as triggered_send_customer_key,
             from {{ source("stitch_sfmc_email", "click") }}  -- is click because UUSA does not have action
             where jobid is not null
-        )
-
-    select
-        account_id,
-        oyb_account_id,
-        job_id,
-        list_id,
-        batch_id,
-        subscriber_id,
-        subscriber_key,
-        event_dt,
-        domain,
-        url,
-        link_name,
-        link_content,
-        is_unique,
-        triggerrer_send_definition_object_id,
-        triggered_send_customer_key
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
@@ -1,12 +1,12 @@
 {% macro create_stg_src_stitch_email_action() %}
 
             select
-                cast('' as int64) as account_id,
-                cast('' as int64) as oyb_account_id,
-                cast('' as int64) as job_id,
-                cast('' as int64) as list_id,
-                cast('' as int64) as batch_id,
-                cast('' as int64) as subscriber_id,
+                cast(0 as int64) as account_id,
+                cast(0 as int64) as oyb_account_id,
+                cast(0 as int64) as job_id,
+                cast(0 as int64) as list_id,
+                cast(0 as int64) as batch_id,
+                cast(0 as int64) as subscriber_id,
                 '' as subscriber_key,
                 datetime(''
                 ) as event_dt,

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
@@ -25,7 +25,7 @@
                 cast(isunique as bool) as is_unique,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
                 triggeredsendcustomerkey as triggered_send_customer_key,
-                row_number() over (partition by jobid order by eventdate) as row_num
+                row_number() over (partition by subscriberkey order by eventdate) as row_num
             from {{ source("stitch_sfmc_email", "click") }}  -- is click because UUSA does not have action
             where jobid is not null
         )

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
@@ -1,23 +1,22 @@
 {% macro create_stg_src_stitch_email_action() %}
 
-            select
-                cast(0 as int64) as account_id,
-                cast(0 as int64) as oyb_account_id,
-                cast(0 as int64) as job_id,
-                cast(0 as int64) as list_id,
-                cast(0 as int64) as batch_id,
-                cast(0 as int64) as subscriber_id,
-                '' as subscriber_key,
-                datetime(''
-                ) as event_dt,
-                cast('' as string) as domain,
-                cast('' as string) as url,
-                cast('' as string) as link_name,
-                cast('' as string) as link_content,
-                cast('' as bool) as is_unique,
-                cast('' as string) as triggerrer_send_definition_object_id,
-                cast('' as string) as triggered_send_customer_key,
-            from {{ source("stitch_sfmc_email", "click") }}  -- is click because UUSA does not have action
-            where jobid is not null
+    select
+        cast(0 as int64) as account_id,
+        cast(0 as int64) as oyb_account_id,
+        cast(0 as int64) as job_id,
+        cast(0 as int64) as list_id,
+        cast(0 as int64) as batch_id,
+        cast(0 as int64) as subscriber_id,
+        '' as subscriber_key,
+        datetime('') as event_dt,
+        cast('' as string) as domain,
+        cast('' as string) as url,
+        cast('' as string) as link_name,
+        cast('' as string) as link_content,
+        cast('' as bool) as is_unique,
+        cast('' as string) as triggerrer_send_definition_object_id,
+        cast('' as string) as triggered_send_customer_key,
+    from {{ source("stitch_sfmc_email", "click") }}  -- is click because UUSA does not have action
+    where jobid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
@@ -1,7 +1,4 @@
 {% macro create_stg_src_stitch_email_bounce() %}
-
-    with
-        deduplicated_data as (
             select
                 cast(__accountid_ as int64) as account_id,
                 cast(oybaccountid as int64) as oyb_account_id,
@@ -29,34 +26,8 @@
                 cast(smtpcode as string) as smtp_code,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
                 cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
-                _sdc_received_at as recieved_at,
-                row_number() over (partition by subscriberkey order by eventdate) as row_num
+                _sdc_received_at as recieved_at
             from {{ source("stitch_sfmc_email", "bounce") }}
             where jobid is not null
-        )
-
-    select
-        account_id,
-        oyb_account_id,
-        job_id,
-        list_id,
-        batch_id,
-        subscriber_id,
-        subscriber_key,
-        event_dt,
-        is_unique,
-        domain,
-        bounce_category_id,
-        bounce_category,
-        bounce_subcategory_id,
-        bounce_subcategory,
-        bounce_type_id,
-        bounce_type,
-        smtp_code,
-        triggerrer_send_definition_object_id,
-        triggered_send_customer_key,
-        recieved_at
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
@@ -1,33 +1,29 @@
 {% macro create_stg_src_stitch_email_bounce() %}
-            select
-                cast(__accountid_ as int64) as account_id,
-                cast(oybaccountid as int64) as oyb_account_id,
-                cast(jobid as int64) as job_id,
-                cast(listid as int64) as list_id,
-                cast(batchid as int64) as batch_id,
-                cast(subscriberid as int64) as subscriber_id,
-                subscriberkey as subscriber_key,
-                datetime(
-                    cast(
-                        concat(
-                            substr(eventdate, 0, 22), " America/New_York"
-                        ) as timestamp
-                    ),
-                    "America/New_York"
-                ) as event_dt,
-                cast(isunique as bool) as is_unique,
-                domain,
-                cast(bouncecategoryid as string) as bounce_category_id,
-                bouncecategory as bounce_category,
-                bouncesubcategoryid as bounce_subcategory_id,
-                bouncesubcategory as bounce_subcategory,
-                cast(bouncetypeid as string) as bounce_type_id,
-                bouncetype as bounce_type,
-                cast(smtpcode as string) as smtp_code,
-                triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
-                _sdc_received_at as recieved_at
-            from {{ source("stitch_sfmc_email", "bounce") }}
-            where jobid is not null
+    select
+        cast(__accountid_ as int64) as account_id,
+        cast(oybaccountid as int64) as oyb_account_id,
+        cast(jobid as int64) as job_id,
+        cast(listid as int64) as list_id,
+        cast(batchid as int64) as batch_id,
+        cast(subscriberid as int64) as subscriber_id,
+        subscriberkey as subscriber_key,
+        datetime(
+            cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+            "America/New_York"
+        ) as event_dt,
+        cast(isunique as bool) as is_unique,
+        domain,
+        cast(bouncecategoryid as string) as bounce_category_id,
+        bouncecategory as bounce_category,
+        bouncesubcategoryid as bounce_subcategory_id,
+        bouncesubcategory as bounce_subcategory,
+        cast(bouncetypeid as string) as bounce_type_id,
+        bouncetype as bounce_type,
+        cast(smtpcode as string) as smtp_code,
+        triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+        cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
+        _sdc_received_at as recieved_at
+    from {{ source("stitch_sfmc_email", "bounce") }}
+    where jobid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_bounce.sql
@@ -30,7 +30,7 @@
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
                 cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
                 _sdc_received_at as recieved_at,
-                row_number() over (partition by jobid order by eventdate) as row_num
+                row_number() over (partition by subscriberkey order by eventdate) as row_num
             from {{ source("stitch_sfmc_email", "bounce") }}
             where jobid is not null
         )

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
@@ -25,7 +25,7 @@
                 cast(isunique as bool) as is_unique,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
                 triggeredsendcustomerkey as triggered_send_customer_key,
-                row_number() over (partition by jobid order by eventdate) as row_num
+                row_number() over (partition by subscriberkey order by eventdate) as row_num
             from {{ source("stitch_sfmc_email", "click") }}
             where jobid is not null
         )

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
@@ -1,7 +1,4 @@
 {% macro create_stg_src_stitch_email_click() %}
-
-    with
-        deduplicated_data as (
             select distinct
                 cast(__accountid_ as int64) as account_id,
                 cast(oybaccountid as int64) as oyb_account_id,
@@ -24,29 +21,8 @@
                 linkcontent as link_content,
                 cast(isunique as bool) as is_unique,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                triggeredsendcustomerkey as triggered_send_customer_key,
-                row_number() over (partition by subscriberkey order by eventdate) as row_num
+                triggeredsendcustomerkey as triggered_send_customer_key
             from {{ source("stitch_sfmc_email", "click") }}
             where jobid is not null
-        )
-
-    select distinct
-        account_id,
-        oyb_account_id,
-        job_id,
-        list_id,
-        batch_id,
-        subscriber_id,
-        subscriber_key,
-        event_dt,
-        domain,
-        url,
-        link_name,
-        link_content,
-        is_unique,
-        triggerrer_send_definition_object_id,
-        triggered_send_customer_key
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_click.sql
@@ -1,28 +1,24 @@
 {% macro create_stg_src_stitch_email_click() %}
-            select distinct
-                cast(__accountid_ as int64) as account_id,
-                cast(oybaccountid as int64) as oyb_account_id,
-                cast(jobid as int64) as job_id,
-                cast(listid as int64) as list_id,
-                cast(batchid as int64) as batch_id,
-                cast(subscriberid as int64) as subscriber_id,
-                subscriberkey as subscriber_key,
-                datetime(
-                    cast(
-                        concat(
-                            substr(eventdate, 0, 22), " America/New_York"
-                        ) as timestamp
-                    ),
-                    "America/New_York"
-                ) as event_dt,
-                domain,
-                url,
-                linkname as link_name,
-                linkcontent as link_content,
-                cast(isunique as bool) as is_unique,
-                triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                triggeredsendcustomerkey as triggered_send_customer_key
-            from {{ source("stitch_sfmc_email", "click") }}
-            where jobid is not null
+    select distinct
+        cast(__accountid_ as int64) as account_id,
+        cast(oybaccountid as int64) as oyb_account_id,
+        cast(jobid as int64) as job_id,
+        cast(listid as int64) as list_id,
+        cast(batchid as int64) as batch_id,
+        cast(subscriberid as int64) as subscriber_id,
+        subscriberkey as subscriber_key,
+        datetime(
+            cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+            "America/New_York"
+        ) as event_dt,
+        domain,
+        url,
+        linkname as link_name,
+        linkcontent as link_content,
+        cast(isunique as bool) as is_unique,
+        triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+        triggeredsendcustomerkey as triggered_send_customer_key
+    from {{ source("stitch_sfmc_email", "click") }}
+    where jobid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
@@ -1,24 +1,20 @@
 {% macro create_stg_src_stitch_email_complaint() %}
 
-            select distinct
-                cast(__accountid_ as int64) as account_id,
-                cast(oybaccountid as int64) as oyb_account_id,
-                cast(jobid as int64) as job_id,
-                cast(listid as int64) as list_id,
-                cast(batchid as int64) as batch_id,
-                cast(subscriberid as int64) as subscriber_id,
-                subscriberkey as subscriber_key,
-                datetime(
-                    cast(
-                        concat(
-                            substr(eventdate, 0, 22), " America/New_York"
-                        ) as timestamp
-                    ),
-                    "America/New_York"
-                ) as event_dt,
-                cast(isunique as bool) as is_unique,
-                domain
-            from {{ source("stitch_sfmc_email", "complaint") }}
-            where jobid is not null
+    select distinct
+        cast(__accountid_ as int64) as account_id,
+        cast(oybaccountid as int64) as oyb_account_id,
+        cast(jobid as int64) as job_id,
+        cast(listid as int64) as list_id,
+        cast(batchid as int64) as batch_id,
+        cast(subscriberid as int64) as subscriber_id,
+        subscriberkey as subscriber_key,
+        datetime(
+            cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+            "America/New_York"
+        ) as event_dt,
+        cast(isunique as bool) as is_unique,
+        domain
+    from {{ source("stitch_sfmc_email", "complaint") }}
+    where jobid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
@@ -20,7 +20,7 @@
                 ) as event_dt,
                 cast(isunique as bool) as is_unique,
                 domain,
-                row_number() over (partition by jobid order by eventdate) as row_num
+                row_number() over (partition by subscriberkey order by eventdate) as row_num
             from {{ source("stitch_sfmc_email", "complaint") }}
             where jobid is not null
         )

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_complaint.sql
@@ -1,7 +1,5 @@
 {% macro create_stg_src_stitch_email_complaint() %}
 
-    with
-        deduplicated_data as (
             select distinct
                 cast(__accountid_ as int64) as account_id,
                 cast(oybaccountid as int64) as oyb_account_id,
@@ -19,24 +17,8 @@
                     "America/New_York"
                 ) as event_dt,
                 cast(isunique as bool) as is_unique,
-                domain,
-                row_number() over (partition by subscriberkey order by eventdate) as row_num
+                domain
             from {{ source("stitch_sfmc_email", "complaint") }}
             where jobid is not null
-        )
-
-    select distinct
-        account_id,
-        oyb_account_id,
-        job_id,
-        list_id,
-        batch_id,
-        subscriber_id,
-        subscriber_key,
-        event_dt,
-        is_unique,
-        domain
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journey.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journey.sql
@@ -1,7 +1,5 @@
 {% macro create_stg_src_stitch_email_journey() %}
 
-    with
-        deduplicated_data as (
             select distinct
                 __versionid_ as version_id,
                 journeyid as journey_id,
@@ -53,24 +51,8 @@
                         else null
                     end
                 ) as modified_dt,
-                journeystatus as journey_status,
-                row_number() over (
-                    partition by journeyid order by createddate
-                ) as row_num
+                journeystatus as journey_status
             from {{ source("stitch_sfmc_email", "journey") }}
             where journeyid is not null
-        )
-
-    select distinct
-        version_id,
-        journey_id,
-        journey_name,
-        version_number,
-        created_dt,
-        last_published_dt,
-        modified_dt,
-        journey_status
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journey.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journey.sql
@@ -1,58 +1,57 @@
 {% macro create_stg_src_stitch_email_journey() %}
 
-            select distinct
-                __versionid_ as version_id,
-                journeyid as journey_id,
-                journeyname as journey_name,
-                cast(versionnumber as int64) as version_number,
-                (
-                    case
-                        when length(createddate) > 0
-                        then
-                            datetime(
-                                cast(
-                                    concat(
-                                        substr(createddate, 0, 22), " America/New_York"
-                                    ) as timestamp
-                                ),
-                                "America/New_York"
-                            )
-                        else null
-                    end
-                ) as created_dt,
-                (
-                    case
-                        when length(lastpublisheddate) > 0
-                        then
-                            datetime(
-                                cast(
-                                    concat(
-                                        substr(lastpublisheddate, 0, 22),
-                                        " America/New_York"
-                                    ) as timestamp
-                                ),
-                                "America/New_York"
-                            )
-                        else null
-                    end
-                ) as last_published_dt,
-                (
-                    case
-                        when length(modifieddate) > 0
-                        then
-                            datetime(
-                                cast(
-                                    concat(
-                                        substr(modifieddate, 0, 22), " America/New_York"
-                                    ) as timestamp
-                                ),
-                                "America/New_York"
-                            )
-                        else null
-                    end
-                ) as modified_dt,
-                journeystatus as journey_status
-            from {{ source("stitch_sfmc_email", "journey") }}
-            where journeyid is not null
+    select distinct
+        __versionid_ as version_id,
+        journeyid as journey_id,
+        journeyname as journey_name,
+        cast(versionnumber as int64) as version_number,
+        (
+            case
+                when length(createddate) > 0
+                then
+                    datetime(
+                        cast(
+                            concat(
+                                substr(createddate, 0, 22), " America/New_York"
+                            ) as timestamp
+                        ),
+                        "America/New_York"
+                    )
+                else null
+            end
+        ) as created_dt,
+        (
+            case
+                when length(lastpublisheddate) > 0
+                then
+                    datetime(
+                        cast(
+                            concat(
+                                substr(lastpublisheddate, 0, 22), " America/New_York"
+                            ) as timestamp
+                        ),
+                        "America/New_York"
+                    )
+                else null
+            end
+        ) as last_published_dt,
+        (
+            case
+                when length(modifieddate) > 0
+                then
+                    datetime(
+                        cast(
+                            concat(
+                                substr(modifieddate, 0, 22), " America/New_York"
+                            ) as timestamp
+                        ),
+                        "America/New_York"
+                    )
+                else null
+            end
+        ) as modified_dt,
+        journeystatus as journey_status
+    from {{ source("stitch_sfmc_email", "journey") }}
+    where journeyid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journeyactivity.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journeyactivity.sql
@@ -1,13 +1,13 @@
 {% macro create_stg_src_stitch_email_journeyactivity() %}
 
-            select distinct
-                __versionid_ as version_id,
-                activityid as activity_id,
-                activityname as activity_name,
-                activityexternalkey as activity_external_key,
-                journeyactivityobjectid as journey_activity_object_id,
-                activitytype as activity_type
-            from {{ source("stitch_sfmc_email", "journeyactivity") }}
-            where activityid is not null
+    select distinct
+        __versionid_ as version_id,
+        activityid as activity_id,
+        activityname as activity_name,
+        activityexternalkey as activity_external_key,
+        journeyactivityobjectid as journey_activity_object_id,
+        activitytype as activity_type
+    from {{ source("stitch_sfmc_email", "journeyactivity") }}
+    where activityid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journeyactivity.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_journeyactivity.sql
@@ -1,29 +1,13 @@
 {% macro create_stg_src_stitch_email_journeyactivity() %}
 
-    with
-        deduplicated_data as (
             select distinct
                 __versionid_ as version_id,
                 activityid as activity_id,
                 activityname as activity_name,
                 activityexternalkey as activity_external_key,
                 journeyactivityobjectid as journey_activity_object_id,
-                activitytype as activity_type,
-                row_number() over (
-                    partition by activityid order by __versionid_
-                ) as row_num
+                activitytype as activity_type
             from {{ source("stitch_sfmc_email", "journeyactivity") }}
             where activityid is not null
-        )
-
-    select distinct
-        version_id,
-        activity_id,
-        activity_name,
-        activity_external_key,
-        journey_activity_object_id,
-        activity_type
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
@@ -1,7 +1,4 @@
 {% macro create_stg_src_stitch_email_open() %}
-
-    with
-        deduplicated_data as (
             select distinct
                 cast(__accountid_ as int64) as account_id,
                 cast(oybaccountid as int64) as oyb_account_id,
@@ -21,26 +18,8 @@
                 domain,
                 cast(isunique as bool) as is_unique,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
-                row_number() over (partition by subscriberkey order by eventdate) as row_num
+                cast(triggeredsendcustomerkey as string) as triggered_send_customer_key
             from {{ source("stitch_sfmc_email", "open") }}
             where jobid is not null
-        )
-
-    select distinct
-        account_id,
-        oyb_account_id,
-        job_id,
-        list_id,
-        batch_id,
-        subscriber_id,
-        subscriber_key,
-        event_dt,
-        domain,
-        is_unique,
-        triggerrer_send_definition_object_id,
-        triggered_send_customer_key
-    from deduplicated_data
-    where row_num = 1
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
@@ -1,25 +1,21 @@
 {% macro create_stg_src_stitch_email_open() %}
-            select distinct
-                cast(__accountid_ as int64) as account_id,
-                cast(oybaccountid as int64) as oyb_account_id,
-                cast(jobid as int64) as job_id,
-                cast(listid as int64) as list_id,
-                cast(batchid as int64) as batch_id,
-                cast(subscriberid as int64) as subscriber_id,
-                subscriberkey as subscriber_key,
-                datetime(
-                    cast(
-                        concat(
-                            substr(eventdate, 0, 22), " America/New_York"
-                        ) as timestamp
-                    ),
-                    "America/New_York"
-                ) as event_dt,
-                domain,
-                cast(isunique as bool) as is_unique,
-                triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                cast(triggeredsendcustomerkey as string) as triggered_send_customer_key
-            from {{ source("stitch_sfmc_email", "open") }}
-            where jobid is not null
+    select distinct
+        cast(__accountid_ as int64) as account_id,
+        cast(oybaccountid as int64) as oyb_account_id,
+        cast(jobid as int64) as job_id,
+        cast(listid as int64) as list_id,
+        cast(batchid as int64) as batch_id,
+        cast(subscriberid as int64) as subscriber_id,
+        subscriberkey as subscriber_key,
+        datetime(
+            cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+            "America/New_York"
+        ) as event_dt,
+        domain,
+        cast(isunique as bool) as is_unique,
+        triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+        cast(triggeredsendcustomerkey as string) as triggered_send_customer_key
+    from {{ source("stitch_sfmc_email", "open") }}
+    where jobid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_open.sql
@@ -22,7 +22,7 @@
                 cast(isunique as bool) as is_unique,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
                 cast(triggeredsendcustomerkey as string) as triggered_send_customer_key,
-                row_number() over (partition by jobid order by eventdate) as row_num
+                row_number() over (partition by subscriberkey order by eventdate) as row_num
             from {{ source("stitch_sfmc_email", "open") }}
             where jobid is not null
         )

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_sent.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_sent.sql
@@ -21,7 +21,7 @@
                 domain,
                 triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
                 triggeredsendcustomerkey as triggered_send_customer_key,
-                row_number() over (partition by jobid order by eventdate) as row_num
+                row_number() over (partition by subscriberkey order by eventdate) as row_num
             from {{ source("stitch_sfmc_email", "sent") }}
             where jobid is not null
         )

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_sent.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_sent.sql
@@ -1,44 +1,20 @@
 {% macro create_stg_src_stitch_email_sent() %}
-
-    with
-        deduplicated_data as (
-            select distinct
-                cast(__accountid_ as int64) as account_id,
-                cast(oybaccountid as int64) as oyb_account_id,
-                cast(jobid as int64) as message_id,
-                cast(listid as int64) as list_id,
-                cast(batchid as int64) as batch_id,
-                cast(subscriberid as int64) as subscriber_id,
-                subscriberkey as subscriber_key,
-                datetime(
-                    cast(
-                        concat(
-                            substr(eventdate, 0, 22), " America/New_York"
-                        ) as timestamp
-                    ),
-                    "America/New_York"
-                ) as event_dt,
-                domain,
-                triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
-                triggeredsendcustomerkey as triggered_send_customer_key,
-                row_number() over (partition by subscriberkey order by eventdate) as row_num
-            from {{ source("stitch_sfmc_email", "sent") }}
-            where jobid is not null
-        )
-
     select distinct
-        account_id,
-        oyb_account_id,
-        message_id,
-        list_id,
-        batch_id,
-        subscriber_id,
-        subscriber_key,
-        event_dt,
+        cast(__accountid_ as int64) as account_id,
+        cast(oybaccountid as int64) as oyb_account_id,
+        cast(jobid as int64) as message_id,
+        cast(listid as int64) as list_id,
+        cast(batchid as int64) as batch_id,
+        cast(subscriberid as int64) as subscriber_id,
+        subscriberkey as subscriber_key,
+        datetime(
+            cast(concat(substr(eventdate, 0, 22), " America/New_York") as timestamp),
+            "America/New_York"
+        ) as event_dt,
         domain,
-        triggerrer_send_definition_object_id,
-        triggered_send_customer_key
-    from deduplicated_data
-    where row_num = 1
+        triggerersenddefinitionobjectid as triggerrer_send_definition_object_id,
+        triggeredsendcustomerkey as triggered_send_customer_key
+    from {{ source("stitch_sfmc_email", "sent") }}
+    where jobid is not null
 
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_customizable_email_campaigns.sql
+++ b/macros/stitch_sfmc_email/staging/stg_stitch_sfmc_customizable_email_campaigns.sql
@@ -1,8 +1,8 @@
 {% macro create_stg_stitch_sfmc_customizable_email_campaigns(
     audience,
     source_code_campaign,
-    reference_name="stg_src_stitch_email_job")
- %}
+    reference_name="stg_src_stitch_email_job"
+) %}
 
     select distinct
         safe_cast(job_id as string) as message_id,


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Open the pull request as a draft so that you can run tests against the code and inspect the files in the Files view of the Pull Request interface in Github.

- [x] Once you're satisfied, convert the draft into an open Pull Request by clicking "Ready for Review" near the bottom of this page. You should not make any changes to the code except in dire emergency once you've converted from draft, so make sure you're really satisfied.

- [x] Add two of the principal contributors to this PR for review. Currently, the principal contributors are @dmbluestate , @Frydafly , and @ryantimjohn.

- [x] We've divided our PR templates into Macros, Utils and Docs PR requests. Delete the ones you're not using.
### Macros (delete if not using)

- [ ] Link Jira tickets (or Github Issues) to PR here. Make sure that the Jira ticket has a good description as to why this PR is necessary and the business problem that this PR is solving. Moreover, if there have been any discussions of this ticket in Slack, make sure they're linked in the Jira ticket: https://bluestate.atlassian.net/browse/ARC-1590?atlOrigin=eyJpIjoiMDQ4NmU1YmU0MmUxNDMxMTgyNjEyOGMwMmY5ZjFlODEiLCJwIjoiaiJ9 

- [x] Make sure this is named using Jira extension so that naming convention is consistent. If it's not, that's okay. Go to the Jira ticket, click into the ticket, then on the right under Details, find Development, then click the Create branch button. Copy the Branch Name from there. Read here [how to rename a branch in Github](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch) to rename this branch. In the future, create branches from Jira.

- [x] Make sure the Macro is documented by running the notebook: `create_docs.ipynb` util in this repo. From there, you'll have to either fill in descriptions by hand OR use our `fill_in_descriptions_using_openai.ipynb` to fill in descriptions using OpenAI's ChatGPT. Always make sure to check over ChatGPT's column descriptions, as they're likely not perfect.

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below.

- [x] If new macro files were created or updated, re-run `create_or_update_standard_models.py` for the client dbt project, replacing models and dependencies

- [x] check in dbt that client package successfully runs `dbt deps`, `dbt compile`, and `dbt run`; screenshot this page
<img width="732" alt="Screenshot 2023-08-24 at 4 22 31 PM" src="https://github.com/bsd/dbt-arc-functions/assets/22733009/c718c495-4878-4bdc-beb3-776113a2ff34">

- [x] query the resulting staging model in bigquery (or by previewing mart in dbt cloud, or your IDE); screenshot this
<img width="887" alt="Screenshot 2023-08-24 at 4 44 49 PM" src="https://github.com/bsd/dbt-arc-functions/assets/22733009/97b4499e-97ee-499e-856c-f54e738430fc">



## Formatters

Three different formatters will run when you open a pull request:
- [sqlfmt](http://sqlfmt.com/)
- [yamlfix](https://lyz-code.github.io/yamlfix/)
- [Black(python)](https://pypi.org/project/black/)

If any of them detect syntax problems, they will error. They will automatically open a pull request with the changes you need to make to pass the formatter. Just merge that PR and you should be good to go.

## Linters
We have two in-house linters:

### [check_macros.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_macros.py)
Makes sure that every macro has a doc associated with it in the documentation folder with the same folder structure, i.e.:

`documentation/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.yml`

is the doc for

`       macros/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.sql`

Additionally makes sure that macros are named correctly, i.e. with the naming convention `create_(macro_file_name_stem)`

### [check_docs_correct.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_docs_correct.py)
Runs through a lot of checks on documents to make sure that they are formatted to our standards. This includes checking whether docs and sources:
- have columns
- have tables
- source columns have data_type and description
- have a version number
- docs have a macro associated with them
- docs are not blank
- that model names match the filename stem

There may be additional checks not documented here. The linter will fail on any error.

The script will document all failures and display them to you with remedies.
