### PR TITLE
PATCH -- minor fix for actions, converting the datetime cast to null to reduce errors

### DIFF
--- a/macros/stitch_sfmc_deliverability/staging/stg_stitch_sfmc_deliverability_jobs_distinct.sql
+++ b/macros/stitch_sfmc_deliverability/staging/stg_stitch_sfmc_deliverability_jobs_distinct.sql
@@ -19,7 +19,7 @@
 
     select distinct
         safe_cast(job_id as string) as message_id,
-        safe_cast(event_dt as date) as sent_date,
+        safe_cast(NULLIF(event_dt, '') as DATE) as sent_date,
         safe_cast(domain as string) as email_domain
     from unions
 {% endmacro %}

--- a/macros/stitch_sfmc_deliverability/staging/stg_stitch_sfmc_deliverability_jobs_distinct.sql
+++ b/macros/stitch_sfmc_deliverability/staging/stg_stitch_sfmc_deliverability_jobs_distinct.sql
@@ -19,7 +19,7 @@
 
     select distinct
         safe_cast(job_id as string) as message_id,
-        safe_cast(NULLIF(event_dt, '') as DATE) as sent_date,
+        safe_cast(event_dt as date) as sent_date,
         safe_cast(domain as string) as email_domain
     from unions
 {% endmacro %}

--- a/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
+++ b/macros/stitch_sfmc_email/staging/stg_src_stitch_email_action.sql
@@ -8,14 +8,14 @@
         cast(0 as int64) as batch_id,
         cast(0 as int64) as subscriber_id,
         '' as subscriber_key,
-        datetime('') as event_dt,
+        cast(NULL as datetime) as event_dt,
         cast('' as string) as domain,
         cast('' as string) as url,
         cast('' as string) as link_name,
         cast('' as string) as link_content,
-        cast('' as bool) as is_unique,
-        cast('' as string) as triggerrer_send_definition_object_id,
-        cast('' as string) as triggered_send_customer_key,
+        cast(NULL as bool) as is_unique,
+        cast(NULL as string) as triggerrer_send_definition_object_id,
+        cast(NULL as string) as triggered_send_customer_key,
     from {{ source("stitch_sfmc_email", "click") }}  -- is click because UUSA does not have action
     where jobid is not null
 


### PR DESCRIPTION
`datetime('') as event_dt,` for actions would lead to issues down the line 

switched over to ` cast(NULL as datetime) as event_dt,`