### PR TITLE
Arc 1616 audience reporting bug mart cashflow actuals and budget missing historical transaction data pre 2020

### DIFF
--- a/macros/stitch_sfmc_bbcrm_transactions/staging/stg_src_stitch_sfmc_bbcrm_transaction.sql
+++ b/macros/stitch_sfmc_bbcrm_transactions/staging/stg_src_stitch_sfmc_bbcrm_transaction.sql
@@ -1,6 +1,34 @@
 {% macro create_stg_src_stitch_sfmc_bbcrm_transaction() %}
 
     with
+        revenue_historical as (
+            select
+                bbcrmlookupid,
+                constituentsystemrecordid,
+                statuscode,
+                cast(recordid as string) as recordid,
+                revenue_id,
+                cast(transaction_date as datetime) as transaction_date,
+                payment_method,
+                cast(recognition_amount as string) as amount,
+                inbound_channel,
+                appeal,
+                appeal_business_unit,
+                initial_market_source,
+                web_donation_form_value,
+                web_donation_form_comment,
+                designation,
+                transaction_type,
+                application,
+                vendor_order_number,
+                revenue_platform,
+                sfmc_dateadded,
+                sfmc_updatedate
+            from
+                {{ source("src_uusa_bbcrm_historical","revenue_historical") }}
+
+        ),
+
         current_fiscal_historical as (
             select
                 bbcrmlookupid,
@@ -59,6 +87,9 @@
 
         current_fiscal_unioned as (
 
+            select *
+            from revenue_historical
+            union all
             select *
             from current_fiscal_historical
             union all

--- a/sources/src_uusa_bbcrm_historical.yml
+++ b/sources/src_uusa_bbcrm_historical.yml
@@ -71,3 +71,71 @@ sources:
             data_type: string
             description: The date the revenue was updated in Salesforce Marketing
               Cloud
+
+      - name: revenue_historical
+        description: "Table containing revenue data from Salesforce CRM pre-2020"
+        columns:
+          - name: bbcrmlookupid
+            data_type: string
+            description: The lookup ID in Salesforce CRM for the revenue data
+          - name: constituentsystemrecordid
+            data_type: string
+            description: The ID of the constituent system in Salesforce CRM
+          - name: statuscode
+            data_type: string
+            description: The status code of the revenue in Salesforce CRM
+          - name: recordid
+            data_type: string
+            description: The record ID of the revenue in Salesforce CRM
+          - name: revenue_id
+            data_type: string
+            description: The ID of the revenue in Salesforce CRM
+          - name: transaction_date
+            data_type: string
+            description: The transaction date associated with the revenue
+          - name: payment_method
+            data_type: string
+            description: The payment method associated with the revenue
+          - name: recognition_amount
+            data_type: string
+            description: The amount of revenue to be recognized for financial reporting
+          - name: inbound_channel
+            data_type: string
+            description: The channel through which the revenue was acquired
+          - name: appeal
+            data_type: string
+            description: The fundraising appeal associated with the revenue
+          - name: appeal_business_unit
+            data_type: string
+            description: The business unit associated with the fundraising appeal
+          - name: initial_market_source
+            data_type: string
+            description: The initial marketing source associated with the revenue
+          - name: web_donation_form_value
+            data_type: string
+            description: The value associated with the web donation form
+          - name: web_donation_form_comment
+            data_type: string
+            description: The comment associated with the web donation form
+          - name: designation
+            data_type: string
+            description: The designated area for the revenue
+          - name: transaction_type
+            data_type: string
+            description: The type of transaction associated with the revenue
+          - name: application
+            data_type: string
+            description: The application associated with the revenue
+          - name: vendor_order_number
+            data_type: string
+            description: The vendor order number associated with the revenue
+          - name: revenue_platform
+            data_type: string
+            description: The platform through which the revenue was acquired
+          - name: sfmc_dateadded
+            data_type: string
+            description: The date the revenue was added in Salesforce Marketing Cloud
+          - name: sfmc_updatedate
+            data_type: string
+            description: The date the revenue was updated in Salesforce Marketing
+              Cloud


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Open the pull request as a draft so that you can run tests against the code and inspect the files in the Files view of the Pull Request interface in Github.

- [x] Once you're satisfied, convert the draft into an open Pull Request by clicking "Ready for Review" near the bottom of this page. You should not make any changes to the code except in dire emergency once you've converted from draft, so make sure you're really satisfied.

- [x] Add two of the principal contributors to this PR for review. Currently, the principal contributors are @dmbluestate , @Frydafly , and @ryantimjohn.

### Macros (delete if not using)

- [x] Link Jira tickets (or Github Issues) to PR here. Make sure that the Jira ticket has a good description as to why this PR is necessary and the business problem that this PR is solving. Moreover, if there have been any discussions of this ticket in Slack, make sure they're linked in the Jira ticket: https://bluestate.atlassian.net/browse/ARC-1616

- [x] Make sure this is named using Jira extension so that naming convention is consistent. If it's not, that's okay. Go to the Jira ticket, click into the ticket, then on the right under Details, find Development, then click the Create branch button. Copy the Branch Name from there. Read here [how to rename a branch in Github](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch) to rename this branch. In the future, create branches from Jira.

- [x] Make sure the Macro is documented by running the notebook: `create_docs.ipynb` util in this repo. From there, you'll have to either fill in descriptions by hand OR use our `fill_in_descriptions_using_openai.ipynb` to fill in descriptions using OpenAI's ChatGPT. Always make sure to check over ChatGPT's column descriptions, as they're likely not perfect.

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below.
- [x] ARC UUSA

- [x] If new macro files were created or updated, re-run `create_or_update_standard_models.py` for the client dbt project, replacing models and dependencies

- [x] check in dbt that client package successfully runs `dbt deps`, `dbt compile`, and `dbt run`; screenshot this page

Dbt runs succeeds for the affected models but does timeout on others. The models that timeout do build when I run the build command in the IDE on a per model bases, but the timeout occurs when a job is run.


- [x] query the resulting staging model in bigquery (or by previewing mart in dbt cloud, or your IDE); screenshot this

<img width="1353" alt="Screenshot 2023-10-27 at 5 03 05 PM" src="https://github.com/bsd/dbt-arc-functions/assets/109629735/f0c276ff-9667-4157-a6d7-409d80e64725">



## Formatters

Three different formatters will run when you open a pull request:
- [sqlfmt](http://sqlfmt.com/)
- [yamlfix](https://lyz-code.github.io/yamlfix/)
- [Black(python)](https://pypi.org/project/black/)

If any of them detect syntax problems, they will error. They will automatically open a pull request with the changes you need to make to pass the formatter. Just merge that PR and you should be good to go.

## Linters
We have two in-house linters:

### [check_macros.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_macros.py)
Makes sure that every macro has a doc associated with it in the documentation folder with the same folder structure, i.e.:

`documentation/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.yml`

is the doc for

`       macros/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.sql`

Additionally makes sure that macros are named correctly, i.e. with the naming convention `create_(macro_file_name_stem)`

### [check_docs_correct.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_docs_correct.py)
Runs through a lot of checks on documents to make sure that they are formatted to our standards. This includes checking whether docs and sources:
- have columns
- have tables
- source columns have data_type and description
- have a version number
- docs have a macro associated with them
- docs are not blank
- that model names match the filename stem

There may be additional checks not documented here. The linter will fail on any error.

The script will document all failures and display them to you with remedies.
