### PR TITLE
Arc 1628 no lapsed donors in mart audience budget with audience transaction or recur

### DIFF
--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction.sql
@@ -1,13 +1,12 @@
 {% macro create_stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction(
-    audience="stg_stitch_sfmc_arc_audience_unioned",
     first_gift="stg_stitch_sfmc_audience_transaction_first_gift",
     transactions="stg_stitch_sfmc_arc_audience_union_transaction_joined_enriched",
-    donor_engagement="stg_stitch_sfmc_audience_transaction_person_engagement_with_start_and_end_dates"
+    donor_engagement="stg_stitch_sfmc_donor_engagement_by_date_day"
 ) %}
     select
-        audience.date_day as date_day,
-        audience.person_id as person_id,
-        audience.donor_audience as donor_audience,
+        donor_engagement.date_day as date_day,
+        donor_engagement.person_id as person_id,
+        transactions.coalesced_audience as donor_audience,
         transactions.donor_loyalty as donor_loyalty,
         transactions.nth_transaction_this_fiscal_year
         as nth_transaction_this_fiscal_year,
@@ -19,9 +18,26 @@
         first_gift.join_gift_size_string_recur as join_amount_str_recur,
         first_gift.join_month_year_date as join_month_year_str,
     from
+           (
+            select date_day, person_id, donor_engagement
+            from {{ ref(donor_engagement) }}
+        ) as donor_engagement
+    left join
         (
-            select date_day, person_id, donor_audience from {{ ref(audience) }}
-        ) as audience
+            select
+                person_id,
+                transaction_date_day,
+                donor_loyalty,
+                recurring,
+                gift_size_string,
+                coalesced_audience,
+                row_number() over (
+                    partition by person_id, fiscal_year order by transaction_date_day
+                ) as nth_transaction_this_fiscal_year
+            from {{ ref(transactions) }}
+        ) as transactions
+    on donor_engagement.person_id = transactions.person_id
+    and donor_engagement.date_day = transactions.transaction_date_day
     left join
         (
             select
@@ -32,29 +48,5 @@
                 join_month_year_date
             from {{ ref(first_gift) }}
         ) as first_gift
-        on audience.person_id = first_gift.person_id
-    left join
-        (
-            select
-                person_id,
-                transaction_date_day,
-                donor_loyalty,
-                recurring,
-                gift_size_string,
-                row_number() over (
-                    partition by person_id, fiscal_year order by transaction_date_day
-                ) as nth_transaction_this_fiscal_year
-            from {{ ref(transactions) }}
-        ) as transactions
-        on audience.date_day = transactions.transaction_date_day
-        and audience.person_id = transactions.person_id
-    left join
-        (
-            select person_id, donor_engagement, start_date, end_date
-            from {{ ref(donor_engagement) }}
-        ) as donor_engagement
-        on audience.date_day >= donor_engagement.start_date
-        and (audience.date_day <= donor_engagement.end_date or donor_engagement.end_date is null)
-        and audience.person_id = donor_engagement.person_id
-
+        on donor_engagement.person_id = first_gift.person_id
 {% endmacro %}

--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction.sql
@@ -6,7 +6,10 @@
     select
         donor_engagement.date_day as date_day,
         donor_engagement.person_id as person_id,
-        transactions.coalesced_audience as donor_audience,
+        last_value(transactions.coalesced_audience IGNORE NULLS) OVER (
+            partition by donor_engagement.person_id order by donor_engagement.date_day
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) as donor_audience,
         transactions.donor_loyalty as donor_loyalty,
         transactions.nth_transaction_this_fiscal_year
         as nth_transaction_this_fiscal_year,

--- a/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction.sql
+++ b/macros/stitch_sfmc_audience_transaction/staging/stg_stitch_sfmc_audience_transactions_enriched_rollup_join_person_and_transaction.sql
@@ -3,7 +3,7 @@
     transactions="stg_stitch_sfmc_arc_audience_union_transaction_joined_enriched",
     donor_engagement="stg_stitch_sfmc_donor_engagement_by_date_day"
 ) %}
-{{
+    {{
   config(
     materialized = "table",
     cluster_by = "recurring",
@@ -12,9 +12,10 @@
     select
         donor_engagement.date_day as date_day,
         donor_engagement.person_id as person_id,
-        last_value(transactions.coalesced_audience IGNORE NULLS) OVER (
-            partition by donor_engagement.person_id order by donor_engagement.date_day
-            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        last_value(transactions.coalesced_audience ignore nulls) over (
+            partition by donor_engagement.person_id
+            order by donor_engagement.date_day
+            rows between unbounded preceding and current row
         ) as donor_audience,
         transactions.donor_loyalty as donor_loyalty,
         transactions.nth_transaction_this_fiscal_year
@@ -27,7 +28,7 @@
         first_gift.join_gift_size_string_recur as join_amount_str_recur,
         first_gift.join_month_year_date as join_month_year_str,
     from
-           (
+        (
             select date_day, person_id, donor_engagement
             from {{ ref(donor_engagement) }}
         ) as donor_engagement
@@ -45,8 +46,8 @@
                 ) as nth_transaction_this_fiscal_year
             from {{ ref(transactions) }}
         ) as transactions
-    on donor_engagement.person_id = transactions.person_id
-    and donor_engagement.date_day = transactions.transaction_date_day
+        on donor_engagement.person_id = transactions.person_id
+        and donor_engagement.date_day = transactions.transaction_date_day
     left join
         (
             select


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Open the pull request as a draft so that you can run tests against the code and inspect the files in the Files view of the Pull Request interface in Github.

- [x] Once you're satisfied, convert the draft into an open Pull Request by clicking "Ready for Review" near the bottom of this page. You should not make any changes to the code except in dire emergency once you've converted from draft, so make sure you're really satisfied.

- [x] Add two of the principal contributors to this PR for review. Currently, the principal contributors are @dmbluestate , @Frydafly , and @ryantimjohn.

- [x] We've divided our PR templates into Macros, Utils and Docs PR requests. Delete the ones you're not using.
### Macros (delete if not using)

- [x] Link Jira tickets (or Github Issues) to PR here. Make sure that the Jira ticket has a good description as to why this PR is necessary and the business problem that this PR is solving. Moreover, if there have been any discussions of this ticket in Slack, make sure they're linked in the Jira ticket:

https://bluestate.atlassian.net/browse/ARC-1628

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below.

https://github.com/bsd/arc-uusa-dbt/pull/70

- [x] check in dbt that client package successfully runs `dbt deps`, `dbt compile`, and `dbt run`; screenshot this page

![Screenshot 2023-11-16 at 1 35 00 PM](https://github.com/bsd/dbt-arc-functions/assets/16624855/afae2999-46f7-479a-9353-7ec4fdb9665a)

- [x] query the resulting staging model in bigquery (or by previewing mart in dbt cloud, or your IDE); screenshot this

![Screenshot 2023-11-16 at 1 33 12 PM](https://github.com/bsd/dbt-arc-functions/assets/16624855/92acaf3e-5cd5-4f23-b51e-a018213ccd82)

![Screenshot 2023-11-16 at 1 33 03 PM](https://github.com/bsd/dbt-arc-functions/assets/16624855/7d8b7c43-7b1b-4d20-99fa-802c90445559)

AND NO MAJOR DIP AROUND 05-08-2023 AS BEFORE @dmbluestate 

![Screenshot 2023-11-16 at 1 36 45 PM](https://github.com/bsd/dbt-arc-functions/assets/16624855/becb1775-e44b-49a7-a5bf-8b721e07dd33)

