### PR TITLE
PATCH: fix field in arc-1727 that "broke" channel

### DIFF
--- a/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget.sql
+++ b/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget.sql
@@ -9,8 +9,8 @@
                 audience_transactions.transaction_date_day as date_day,
                 audience_transactions.fiscal_year,
                 audience_transactions.coalesced_audience as donor_audience,
-                -- appeal business unit as channel for ONLY this mart
-                audience_transactions.appeal_business_unit as channel,
+                case when recurring = True then audience_transactions.appeal_business_unit 
+                else audience_transactions.channel end as channel,
                 sum(audience_transactions.amount) as total_revenue_actuals,
                 sum(audience_transactions.gift_count) as total_gifts_actuals
             from {{ ref(audience_transactions) }} as audience_transactions


### PR DESCRIPTION
**Request from Stephen:** 
Move recurring revenue to the ABU code so all recurring revenue is tracked to ABU. The same concept we had before with the "recurring" channel.
Before we had a channel called "recurring"
And every transaction that had an IM_ ABU code went to that channel
Rather than have just a single channel called "recurring"
We want IM_DIG and IM_FTF and IM_DTV etc.
It is like saying Recurring Online Recurring FTF Recurring DTV etc.

**Code change is one line **