### PR TITLE
Part 2 - PATCH: Arc 1727-- hodgepodge of changes from meeting with Stephen 

### DIFF
--- a/macros/audience_budget_with_audience_transaction/marts/mart_audience_budget_with_audience_transaction.sql
+++ b/macros/audience_budget_with_audience_transaction/marts/mart_audience_budget_with_audience_transaction.sql
@@ -10,7 +10,7 @@
         coalesce(
             onetime_donor_counts.donor_audience, audience_budget.donor_audience
         ) as donor_audience,
-        coalesce(onetime_donor_counts.platform, audience_budget.join_source) as channel,
+        coalesce(initcap(onetime_donor_counts.platform), initcap(audience_budget.join_source)) as channel,
         onetime_donor_counts.total_onetime_donor_counts as total_onetime_donor_counts,
         onetime_donor_counts.new_onetime_donor_counts as new_onetime_donor_counts,
         onetime_donor_counts.retained_onetime_donor_counts

--- a/macros/audience_budget_with_audience_transaction/marts/mart_audience_budget_with_audience_transaction_recur.sql
+++ b/macros/audience_budget_with_audience_transaction/marts/mart_audience_budget_with_audience_transaction_recur.sql
@@ -10,7 +10,7 @@
         coalesce(
             audience_budget.donor_audience, recur_donor_counts.donor_audience
         ) as donor_audience,
-        coalesce(recur_donor_counts.platform, audience_budget.join_source) as platform,
+        coalesce(recur_donor_counts.platform, audience_budget.join_source) as channel,
         recur_donor_counts.total_recur_donor_counts as total_recur_donor_counts,
         recur_donor_counts.new_recur_donor_counts as new_recur_donor_counts,
         recur_donor_counts.retained_recur_donor_counts as retained_recur_donor_counts,

--- a/macros/audience_budget_with_audience_transaction/marts/mart_audience_budget_with_audience_transaction_recur.sql
+++ b/macros/audience_budget_with_audience_transaction/marts/mart_audience_budget_with_audience_transaction_recur.sql
@@ -10,7 +10,7 @@
         coalesce(
             audience_budget.donor_audience, recur_donor_counts.donor_audience
         ) as donor_audience,
-        coalesce(recur_donor_counts.platform, audience_budget.join_source) as channel,
+        coalesce(initcap(recur_donor_counts.platform), initcap(audience_budget.join_source)) as channel,
         recur_donor_counts.total_recur_donor_counts as total_recur_donor_counts,
         recur_donor_counts.new_recur_donor_counts as new_recur_donor_counts,
         recur_donor_counts.retained_recur_donor_counts as retained_recur_donor_counts,

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -7,7 +7,7 @@ with base as (
         extract(year from transaction_date_day) as transaction_date_year,
         extract(month from transaction_date_day) as transaction_date_month,
         transaction_date_day as transaction_date_day,
-        SUM(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count
+        SUM(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count,
         count(distinct person_id) as donors,
         sum(amount) as summed_amount,
     from {{ ref(reference_name) }}
@@ -32,7 +32,7 @@ case
     then "6-12"
     when cumulative_gift_count between 13 and 24
     then "13-24"
-    when cumulatiove_gift_count between 25 and 36
+    when cumulative_gift_count between 25 and 36
     then "25-36"
     else "37+"
 end as recurring_gift_cumulative_str

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -32,7 +32,7 @@
                 transaction_date_day,
                 donor_audience,
                 channel,
-                person_id
+                person_id,
                 amount,
                 gift_count
         )

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -26,7 +26,7 @@ with base as (
     amount,
     sum(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count
     from base
-    group by 1, 2
+    group by 1, 2, 3
 )
 
 select 

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -24,7 +24,7 @@
                 channel,
                 person_id,
                 amount,
-                sum(gift_count) over (
+                sum(gift_count) over (partition by person_id
                     order by transaction_date_day
                 ) as cumulative_gift_count
             from base

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -20,7 +20,7 @@ with base as (
 , cumulative_base as (
     select 
     transaction_date_day,
-    new_donor_audience,
+    donor_audience,
     channel,
     donors
     amount,
@@ -31,7 +31,7 @@ with base as (
 
 select 
 transaction_date_day,
-new_donor_audience,
+donor_audience,
 channel,
 donors,
 summed_amount,

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -22,11 +22,11 @@ with base as (
     transaction_date_day,
     donor_audience,
     channel,
-    donors
+    donors,
     amount,
     sum(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count
     from base
-    group by 1, 2, 3
+    group by transaction_date_day, donor_audience, channel, donors, amount, gift_count
 )
 
 select 
@@ -34,7 +34,7 @@ transaction_date_day,
 donor_audience,
 channel,
 donors,
-summed_amount,
+amount,
 cumulative_gift_count,
 case
     when cumulative_gift_count < 6
@@ -47,6 +47,6 @@ case
     then "25-36"
     else "37+"
 end as recurring_gift_cumulative_str
-from base
+from cumulative_base
 
 {% endmacro %}

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -8,7 +8,7 @@
                 transaction_date_day as transaction_date_day,
                 coalesced_audience as donor_audience,
                 channel,
-                person_id
+                person_id,
                 sum(gift_count) as gift_count,
                 sum(amount) as amount
             from {{ ref(reference_name) }}

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -9,7 +9,7 @@ with base as (
         transaction_date_day as transaction_date_day,
         SUM(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count,
         count(distinct person_id) as donors,
-        sum(amount) as summed_amount,
+        sum(amount) as summed_amount
     from {{ ref(reference_name) }}
     where recurring = true
     group by 1, 2, 3, 4

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -26,7 +26,7 @@ with base as (
     amount,
     sum(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count
     from base
-    group by 1, 2, 3, 4, 5
+    group by 1, 2
 )
 
 select 

--- a/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
+++ b/macros/stitch_sfmc_arc/staging/stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts.sql
@@ -1,26 +1,41 @@
 {% macro create_stg_stitch_sfmc_arc_revenue_and_donor_count_by_lifetime_gifts(
     reference_name="stg_stitch_sfmc_arc_audience_union_transaction_joined_enriched"
 ) %}
+
+with base as (
     select
         extract(year from transaction_date_day) as transaction_date_year,
         extract(month from transaction_date_day) as transaction_date_month,
         transaction_date_day as transaction_date_day,
-        case
-            when gift_count < 6
-            then "less than 6"
-            when gift_count between 6 and 12
-            then "6-12"
-            when gift_count between 13 and 24
-            then "13-24"
-            when gift_count between 25 and 36
-            then "25-36"
-            else "37+"
-        end as recurring_gift_cumulative_str,
+        SUM(gift_count) OVER (ORDER BY transaction_date_day) AS cumulative_gift_count
         count(distinct person_id) as donors,
         sum(amount) as summed_amount,
     from {{ ref(reference_name) }}
     where recurring = true
     group by 1, 2, 3, 4
     order by 1, 2, 3, 4
+
+)
+
+select 
+transaction_date_year,
+transaction_date_month,
+transaction_date_day,
+cumulative_gift_count,
+donors,
+summed_amount,
+-- create cumulative value for gift count
+case
+    when cumulative_gift_count < 6
+    then "less than 6"
+    when cumulative_gift_count between 6 and 12
+    then "6-12"
+    when cumulative_gift_count between 13 and 24
+    then "13-24"
+    when cumulatiove_gift_count between 25 and 36
+    then "25-36"
+    else "37+"
+end as recurring_gift_cumulative_str
+from base
 
 {% endmacro %}

--- a/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget.sql
+++ b/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget.sql
@@ -12,7 +12,7 @@
                 case
                     when recurring = true
                     then initcap(audience_transactions.appeal_business_unit)
-                    else audience_transactions.channel
+                    else initcap(audience_transactions.channel)
                 end as channel,
                 sum(audience_transactions.amount) as total_revenue_actuals,
                 sum(audience_transactions.gift_count) as total_gifts_actuals

--- a/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget.sql
+++ b/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget.sql
@@ -11,7 +11,7 @@
                 audience_transactions.coalesced_audience as donor_audience,
                 case
                     when recurring = true
-                    then audience_transactions.appeal_business_unit
+                    then initcap(audience_transactions.appeal_business_unit)
                     else audience_transactions.channel
                 end as channel,
                 sum(audience_transactions.amount) as total_revenue_actuals,

--- a/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget_1x_revenue.sql
+++ b/macros/stitch_sfmc_audience_transaction/marts/mart_cashflow_actuals_and_budget_1x_revenue.sql
@@ -8,7 +8,7 @@
             select
                 audience_transactions.transaction_date_day as date_day,
                 audience_transactions.coalesced_audience as donor_audience,
-                lower(audience_transactions.channel) as channel,
+                initcap(audience_transactions.channel) as channel,
                 audience_transactions.recurring as recur_flag,
                 audience_transactions.fiscal_year,
                 sum(audience_transactions.amount) as total_revenue_actuals,


### PR DESCRIPTION
# Pull Request for dbt-arc-functions

- [x] Open the pull request as a draft so that you can run tests against the code and inspect the files in the Files view of the Pull Request interface in Github.

- [x] Once you're satisfied, convert the draft into an open Pull Request by clicking "Ready for Review" near the bottom of this page. You should not make any changes to the code except in dire emergency once you've converted from draft, so make sure you're really satisfied.

- [x] Add two of the principal contributors to this PR for review. Currently, the principal contributors are @dmbluestate , @Frydafly , and @ryantimjohn.

- [x] We've divided our PR templates into Macros, Utils and Docs PR requests. Delete the ones you're not using.
### Macros (delete if not using)

- [ ] Link Jira tickets (or Github Issues) to PR here. Make sure that the Jira ticket has a good description as to why this PR is necessary and the business problem that this PR is solving. Moreover, if there have been any discussions of this ticket in Slack, make sure they're linked in the Jira ticket:

- [x] Make sure this is named using Jira extension so that naming convention is consistent. If it's not, that's okay. Go to the Jira ticket, click into the ticket, then on the right under Details, find Development, then click the Create branch button. Copy the Branch Name from there. Read here [how to rename a branch in Github](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch) to rename this branch. In the future, create branches from Jira.

- [ ] Make sure the Macro is documented by running the notebook: `create_docs.ipynb` util in this repo. From there, you'll have to either fill in descriptions by hand OR use our `fill_in_descriptions_using_openai.ipynb` to fill in descriptions using OpenAI's ChatGPT. Always make sure to check over ChatGPT's column descriptions, as they're likely not perfect.

- [x] Test branch on a development branch of an existing client (ideally the one that raised the bug). Do this by changing revision of the package to the branch name in `packages.yml` file in dbt State client below.

- [ ] If new macro files were created or updated, re-run `create_or_update_standard_models.py` for the client dbt project, replacing models and dependencies

- [x] check in dbt that client package successfully runs `dbt deps`, `dbt compile`, and `dbt run`; screenshot this page
https://github.com/bsd/arc-uusa-dbt/pull/81

- [x] query the resulting staging model in bigquery (or by previewing mart in dbt cloud, or your IDE); screenshot this

## Formatters

Three different formatters will run when you open a pull request:
- [sqlfmt](http://sqlfmt.com/)
- [yamlfix](https://lyz-code.github.io/yamlfix/)
- [Black(python)](https://pypi.org/project/black/)

If any of them detect syntax problems, they will error. They will automatically open a pull request with the changes you need to make to pass the formatter. Just merge that PR and you should be good to go.

## Linters
We have two in-house linters:

### [check_macros.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_macros.py)
Makes sure that every macro has a doc associated with it in the documentation folder with the same folder structure, i.e.:

`documentation/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.yml`

is the doc for

`       macros/combined_email_paidmedia/marts/mart_combined_email_paidmedia_daily_revenue_performance.sql`

Additionally makes sure that macros are named correctly, i.e. with the naming convention `create_(macro_file_name_stem)`

### [check_docs_correct.py](https://github.com/bsd/dbt-arc-functions/blob/main/utils/check_docs_correct.py)
Runs through a lot of checks on documents to make sure that they are formatted to our standards. This includes checking whether docs and sources:
- have columns
- have tables
- source columns have data_type and description
- have a version number
- docs have a macro associated with them
- docs are not blank
- that model names match the filename stem

There may be additional checks not documented here. The linter will fail on any error.

The script will document all failures and display them to you with remedies.
